### PR TITLE
デバッグビルドでも60FPSを出すために各種最適化

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,6 +25,7 @@ jobs:
         .\vcpkg install picojson
         .\vcpkg install freetype
         .\vcpkg install imgui[core,dx12-binding,win32-binding]:x64-windows
+        .\vcpkg install stduuid
     - name: build
       run: |
         cmake -S src -B build -G "Visual Studio 17 2022"

--- a/Solid.code-workspace
+++ b/Solid.code-workspace
@@ -33,6 +33,10 @@
 			"name": "Scene"
 		},
 		{
+			"path": "src/App/mod/Uuid",
+			"name": "Uuid"
+		},
+		{
 			"path": "src/App/mod/Utils",
 			"name": "Utils"
 		},

--- a/Solid.code-workspace
+++ b/Solid.code-workspace
@@ -132,7 +132,11 @@
 			"queue": "cpp",
 			"stack": "cpp",
 			"variant": "cpp",
-			"cassert": "cpp"
+			"cassert": "cpp",
+			"semaphore": "cpp",
+			"coroutine": "cpp",
+			"resumable": "cpp",
+			"future": "cpp"
 		},
 		"files.exclude": {
 			"**/.git": true,

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ vcpkg install directxtex
 vcpkg install picojson
 vcpkg install freetype
 vcpkg install imgui[core,dx12-binding,win32-binding]:x64-windows
+vcpkg install stduuid
 ````
 
 ここから先のセットアップ手順は開発環境により異なります。

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -20,6 +20,7 @@ endfunction()
 # Submodules
 #
 add_subdirectory(./mod/Json)
+add_subdirectory(./mod/Uuid)
 add_subdirectory(./mod/Input)
 add_subdirectory(./mod/Math)
 add_subdirectory(./mod/Graphics)
@@ -102,12 +103,14 @@ target_include_directories(
     "${MODS}/Math/include"
     "${MODS}/OS/include"
     "${MODS}/Scene/include"
+    "${MODS}/Uuid/include"
     "${MODS}/Utils/include"
 )
 target_link_libraries(
     App
     PRIVATE
     Lib-Json
+    Lib-Uuid
     Lib-Input
     Lib-Math
     Lib-Graphics

--- a/src/App/include/Common/Graphics/Node.hpp
+++ b/src/App/include/Common/Graphics/Node.hpp
@@ -31,7 +31,6 @@ public:
 
     void setLocalRotation(const Vector3& localRotation);
     Vector3 getLocalRotation() const;
-    Matrix getGlobalRotation() const;
 
     void setSize(const Vector3& size);
     Vector3 getSize() const;
@@ -43,6 +42,8 @@ public:
     Matrix computeLocalTransform();
     Matrix getGlobalTransform() const;
     Matrix computeGlobalTransform();
+    Matrix getGlobalRotation() const;
+    Matrix computeGlobalRotation();
     std::array<Vector3, 8> getEdges() const;
     std::array<Vector3, 8> computeEdges();
     Geom::OBB getOBB() const;
@@ -69,6 +70,7 @@ private:
     Vector3 m_color;
     Matrix m_localTransform;
     Matrix m_globalTransform;
+    Matrix m_globalRotation;
     std::array<Vector3, 8> m_edges;
     Geom::OBB m_obb;
     bool m_isInvalid;

--- a/src/App/include/Common/Graphics/ParticleBase.hpp
+++ b/src/App/include/Common/Graphics/ParticleBase.hpp
@@ -72,19 +72,15 @@ public:
         uCamera.modelMatrix = Matrix::scale(m_scale);
         uCamera.viewMatrix = Camera::getLookAtMatrix();
         uCamera.projectionMatrix = Camera::getPerspectiveMatrix();
-        // m_uniformBuffer->setVS(0, &uCamera);
         surface->uniformVS(m_uniformBuffer, 0, &uCamera);
 
         Reflect::UVector4 uColor;
         uColor.value = Vector4(m_color, 1.0f);
-        // m_uniformBuffer->setVS(1, &uColor);
         surface->uniformVS(m_uniformBuffer, 1, &uColor);
 
         Reflect::UFloat uDeltatime;
         uDeltatime.value = Time::deltaTime();
-        // m_uniformBuffer->setCS(0, &uDeltatime);
         surface->uniformCS(m_uniformBuffer, 0, &uDeltatime);
-        // m_uniformBuffer->setCS(1, m_instanceBuffer->getGpuBuffer());
         surface->uniformCS(m_uniformBuffer, 1, m_instanceBuffer->getGpuBuffer());
 
         auto rc = RenderContext::get(Metadata::ProgramTable::ParticleInstance3D);

--- a/src/App/include/Common/Graphics/ParticleBase.hpp
+++ b/src/App/include/Common/Graphics/ParticleBase.hpp
@@ -67,24 +67,28 @@ public:
 
     void draw(const std::shared_ptr<CpuBuffer>& vertexBuffer, const std::shared_ptr<CpuBuffer>& indexBuffer, int32_t indexLength) override
     {
+        auto surface = Engine::getInstance()->getDevice()->getSurface();
         Reflect::UCamera uCamera;
         uCamera.modelMatrix = Matrix::scale(m_scale);
         uCamera.viewMatrix = Camera::getLookAtMatrix();
         uCamera.projectionMatrix = Camera::getPerspectiveMatrix();
-        m_uniformBuffer->setVS(0, &uCamera);
+        // m_uniformBuffer->setVS(0, &uCamera);
+        surface->setVS(m_uniformBuffer, 0, &uCamera);
 
         Reflect::UVector4 uColor;
         uColor.value = Vector4(m_color, 1.0f);
-        m_uniformBuffer->setVS(1, &uColor);
+        // m_uniformBuffer->setVS(1, &uColor);
+        surface->setVS(m_uniformBuffer, 1, &uColor);
 
         Reflect::UFloat uDeltatime;
         uDeltatime.value = Time::deltaTime();
-        m_uniformBuffer->setCS(0, &uDeltatime);
-        m_uniformBuffer->setCS(1, m_instanceBuffer->getGpuBuffer());
+        // m_uniformBuffer->setCS(0, &uDeltatime);
+        surface->setCS(m_uniformBuffer, 0, &uDeltatime);
+        // m_uniformBuffer->setCS(1, m_instanceBuffer->getGpuBuffer());
+        surface->setCS(m_uniformBuffer, 1, m_instanceBuffer->getGpuBuffer());
 
         auto rc = RenderContext::get(Metadata::ProgramTable::ParticleInstance3D);
 
-        auto surface = Engine::getInstance()->getDevice()->getSurface();
         surface->sync(m_instanceBuffer);
 
         int32_t threads = (NumParticles + 255) / 256;

--- a/src/App/include/Common/Graphics/ParticleBase.hpp
+++ b/src/App/include/Common/Graphics/ParticleBase.hpp
@@ -73,19 +73,19 @@ public:
         uCamera.viewMatrix = Camera::getLookAtMatrix();
         uCamera.projectionMatrix = Camera::getPerspectiveMatrix();
         // m_uniformBuffer->setVS(0, &uCamera);
-        surface->setVS(m_uniformBuffer, 0, &uCamera);
+        surface->uniformVS(m_uniformBuffer, 0, &uCamera);
 
         Reflect::UVector4 uColor;
         uColor.value = Vector4(m_color, 1.0f);
         // m_uniformBuffer->setVS(1, &uColor);
-        surface->setVS(m_uniformBuffer, 1, &uColor);
+        surface->uniformVS(m_uniformBuffer, 1, &uColor);
 
         Reflect::UFloat uDeltatime;
         uDeltatime.value = Time::deltaTime();
         // m_uniformBuffer->setCS(0, &uDeltatime);
-        surface->setCS(m_uniformBuffer, 0, &uDeltatime);
+        surface->uniformCS(m_uniformBuffer, 0, &uDeltatime);
         // m_uniformBuffer->setCS(1, m_instanceBuffer->getGpuBuffer());
-        surface->setCS(m_uniformBuffer, 1, m_instanceBuffer->getGpuBuffer());
+        surface->uniformCS(m_uniformBuffer, 1, m_instanceBuffer->getGpuBuffer());
 
         auto rc = RenderContext::get(Metadata::ProgramTable::ParticleInstance3D);
 

--- a/src/App/include/Scenes/Game/GameScene.hpp
+++ b/src/App/include/Scenes/Game/GameScene.hpp
@@ -6,6 +6,10 @@
 #include <memory>
 #include <optional>
 
+#ifdef _DEBUG
+#define GAMESCENE_PROFILE 1
+#endif
+
 namespace App::Scenes::Game {
 class GameScene : public IScene {
 public:
@@ -31,7 +35,7 @@ private:
     std::shared_ptr<System::Entities::BasicEntity> m_debugEntity;
     std::shared_ptr<Texture> m_aimTexture;
 
-#if _DEBUG
+#if GAMESCENE_PROFILE
     const float k_fpsK = 0.05f;
     float m_avgTime = 0.0f;
 #endif

--- a/src/App/include/Scenes/Game/System/Entities/BasicEntity.hpp
+++ b/src/App/include/Scenes/Game/System/Entities/BasicEntity.hpp
@@ -58,7 +58,33 @@ private:
     void rehashAABB(const std::shared_ptr<Common::Graphics::Node>& node, Geom::AABB& dst);
     void hitTilesFuzzy(Field& field, const Vector3& offset, std::vector<IntVector3>& hits);
     void hitTilesStrict(Field& field, const std::shared_ptr<Common::Graphics::Node>& node, const Vector3& offset, std::vector<IntVector3>& checkTiles, std::vector<NodeHit>& hits);
-    static float alignTile(float a, float tileSize);
+
+    static inline float alignTile(float a, float tileSize)
+    {
+        float tileHalf = tileSize / 2.0f;
+        float d = a / tileSize;
+        if (d > 0.0f) {
+            d = ::floorf(d);
+        } else {
+            d = ::ceilf(d);
+        }
+        float m = ::fmodf(a, tileSize);
+
+        if (::fabs(m) < 0.000001f) {
+            return a;
+        }
+        if (m > 0.0f) {
+            if (m < tileHalf) {
+                return d * tileSize;
+            }
+            return (d * tileSize) + tileSize;
+        } else {
+            if (::fabs(m) < tileHalf) {
+                return d * tileSize;
+            }
+            return (d * tileSize) - tileSize;
+        }
+    }
 
     std::shared_ptr<Common::Graphics::Node> m_node;
     IntVector3 m_groundTile;

--- a/src/App/include/Scenes/Game/System/Entity.hpp
+++ b/src/App/include/Scenes/Game/System/Entity.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <library.hpp>
 #include <memory>
+#include <stduuid/uuid.h>
+#include <unordered_map>
 
 namespace App::Scenes::Game::System {
 class Field;
@@ -36,6 +38,8 @@ public:
     void setRotation(const Vector3& rotation);
     Vector3 getRotation() const;
 
+    const uuids::uuid& getUuid() const;
+
 protected:
     Entity();
 
@@ -43,10 +47,11 @@ protected:
     virtual void onPositionChanged(const Vector3& position);
     virtual void onRotationChanged(const Vector3& rotation);
 
-    std::vector<std::shared_ptr<Entity>> m_hitTable;
+    std::unordered_map<uuids::uuid, std::shared_ptr<Entity>> m_hitTable;
     int32_t m_maximumHP;
     int32_t m_currentHP;
     Vector3 m_position;
     Vector3 m_rotation;
+    uuids::uuid m_uuid;
 };
 }

--- a/src/App/include/Scenes/Game/System/Field.hpp
+++ b/src/App/include/Scenes/Game/System/Field.hpp
@@ -155,8 +155,22 @@ public:
     FieldGenerator::Room getRoomAt(int32_t index) const;
     int32_t getRoomCount() const;
 
+    static inline int32_t toIndex(int32_t x, int32_t y, int32_t z)
+    {
+        return (z * k_fieldSizeX * k_fieldSizeY) + (y * k_fieldSizeX) + x;
+    }
+    static inline IntVector3 toCoord(int32_t index)
+    {
+        const int z = index / (k_fieldSizeX * k_fieldSizeY);
+        index -= (z * k_fieldSizeX * k_fieldSizeY);
+        const int y = index / k_fieldSizeX;
+        const int x = index % k_fieldSizeX;
+        return IntVector3({ x, y, z });
+    }
+
 private:
-    std::array<std::array<std::array<int32_t, k_fieldSizeX>, k_fieldSizeY>, k_fieldSizeZ> m_blocks;
+    // NOTE: _ITERATOR_DEBUG_LEVELや_CONTAINER_DEBUG_LEVELの影響を受けるstd::arrayは使わない
+    int32_t m_blocks[k_fieldSizeX * k_fieldSizeY * k_fieldSizeZ];
     std::shared_ptr<Entities::PlayerEntity> m_player;
     std::vector<std::shared_ptr<Entity>> m_entities;
 

--- a/src/App/include/Scenes/Game/System/Field.hpp
+++ b/src/App/include/Scenes/Game/System/Field.hpp
@@ -142,8 +142,27 @@ public:
     void draw3D(const std::shared_ptr<Renderer>& renderer);
     void draw2D(const std::shared_ptr<Renderer>& renderer);
 
-    bool hasBlockAt(int32_t x, int32_t y, int32_t z) const;
-    int32_t getBlockAt(int32_t x, int32_t y, int32_t z) const;
+    inline bool hasBlockAt(int32_t x, int32_t y, int32_t z) const
+    {
+        if (x >= k_fieldSizeX || x < 0) {
+            return false;
+        }
+        if (y >= k_fieldSizeY || y < 0) {
+            return false;
+        }
+        if (z >= k_fieldSizeZ || z < 0) {
+            return false;
+        }
+        return true;
+    }
+
+    inline int32_t getBlockAt(int32_t x, int32_t y, int32_t z) const
+    {
+        if (!hasBlockAt(x, y, z)) {
+            return 1;
+        }
+        return m_blocks[toIndex(x, y, z)];
+    }
 
     void setPlayer(const std::shared_ptr<Entities::PlayerEntity>& player);
     std::shared_ptr<Entities::PlayerEntity> getPlayer() const;

--- a/src/App/lib/Common/Graphics/Node.cpp
+++ b/src/App/lib/Common/Graphics/Node.cpp
@@ -44,6 +44,7 @@ void Node::validate()
 
         m_localTransform = computeLocalTransform();
         m_globalTransform = computeGlobalTransform();
+        m_globalRotation = computeGlobalRotation();
         m_edges = computeEdges();
         m_obb = computeOBB();
 

--- a/src/App/lib/Common/Graphics/Node.cpp
+++ b/src/App/lib/Common/Graphics/Node.cpp
@@ -281,7 +281,7 @@ Node::Node()
 }
 void Node::draw(const std::shared_ptr<Node>& parent, const std::shared_ptr<Renderer>& renderer, const Vector3& blendColor, float blendRate)
 {
-    float thickness = 0.25f;
+    // float thickness = 0.25f;
     Vector4 color = Vector4(m_color, 1.0f);
     color.x() = Mathf::clamp(0.0f, 1.0f, (1.0f - blendRate) * color.x() + (blendRate * blendColor.x()));
     color.y() = Mathf::clamp(0.0f, 1.0f, (1.0f - blendRate) * color.y() + (blendRate * blendColor.y()));

--- a/src/App/lib/Common/Graphics/Node.cpp
+++ b/src/App/lib/Common/Graphics/Node.cpp
@@ -288,66 +288,8 @@ void Node::draw(const std::shared_ptr<Node>& parent, const std::shared_ptr<Rende
     color.z() = Mathf::clamp(0.0f, 1.0f, (1.0f - blendRate) * color.z() + (blendRate * blendColor.z()));
 
     renderer->pushMatrix(getLocalTransform());
-    {
-        Vector3 offset = Vector3({ thickness / 2.0f, thickness / 2.0f, 0 });
-        Vector3 center = (m_size * Vector3({ 0.5f, 0.5f, 0 })) - offset;
-        renderer->drawBox(center, Vector3({ thickness, thickness, m_size.z() }), Quaternion(), color, false);
-    }
-    {
-        Vector3 offset = Vector3({ -thickness / 2.0f, thickness / 2.0f, 0 });
-        Vector3 center = (m_size * Vector3({ -0.5f, 0.5f, 0 })) - offset;
-        renderer->drawBox(center, Vector3({ thickness, thickness, m_size.z() }), Quaternion(), color, false);
-    }
-    {
-        Vector3 offset = Vector3({ thickness / 2.0f, -thickness / 2.0f, 0 });
-        Vector3 center = (m_size * Vector3({ 0.5f, -0.5f, 0 })) - offset;
-        renderer->drawBox(center, Vector3({ thickness, thickness, m_size.z() }), Quaternion(), color, false);
-    }
-    {
-        Vector3 offset = Vector3({ -thickness / 2.0f, -thickness / 2.0f, 0 });
-        Vector3 center = (m_size * Vector3({ -0.5f, -0.5f, 0 })) - offset;
-        renderer->drawBox(center, Vector3({ thickness, thickness, m_size.z() }), Quaternion(), color, false);
-    }
-    {
-        Vector3 offset = Vector3({ thickness / 2.0f, 0, thickness / 2.0f });
-        Vector3 center = (m_size * Vector3({ 0.5f, 0, 0.5f })) - offset;
-        renderer->drawBox(center, Vector3({ thickness, m_size.y(), thickness }), Quaternion(), color, false);
-    }
-    {
-        Vector3 offset = Vector3({ thickness / 2.0f, 0, -thickness / 2.0f });
-        Vector3 center = (m_size * Vector3({ 0.5f, 0, -0.5f })) - offset;
-        renderer->drawBox(center, Vector3({ thickness, m_size.y(), thickness }), Quaternion(), color, false);
-    }
-    {
-        Vector3 offset = Vector3({ -thickness / 2.0f, 0, thickness / 2.0f });
-        Vector3 center = (m_size * Vector3({ -0.5f, 0, 0.5f })) - offset;
-        renderer->drawBox(center, Vector3({ thickness, m_size.y(), thickness }), Quaternion(), color, false);
-    }
-    {
-        Vector3 offset = Vector3({ -thickness / 2.0f, 0, -thickness / 2.0f });
-        Vector3 center = (m_size * Vector3({ -0.5f, 0, -0.5f })) - offset;
-        renderer->drawBox(center, Vector3({ thickness, m_size.y(), thickness }), Quaternion(), color, false);
-    }
-    {
-        Vector3 offset = Vector3({ 0, thickness / 2.0f, thickness / 2.0f });
-        Vector3 center = (m_size * Vector3({ 0, 0.5f, 0.5f })) - offset;
-        renderer->drawBox(center, Vector3({ m_size.x(), thickness, thickness }), Quaternion(), color, false);
-    }
-    {
-        Vector3 offset = Vector3({ 0, -thickness / 2.0f, thickness / 2.0f });
-        Vector3 center = (m_size * Vector3({ 0, -0.5f, 0.5f })) - offset;
-        renderer->drawBox(center, Vector3({ m_size.x(), thickness, thickness }), Quaternion(), color, false);
-    }
-    {
-        Vector3 offset = Vector3({ 0, thickness / 2.0f, -thickness / 2.0f });
-        Vector3 center = (m_size * Vector3({ 0, 0.5f, -0.5f })) - offset;
-        renderer->drawBox(center, Vector3({ m_size.x(), thickness, thickness }), Quaternion(), color, false);
-    }
-    {
-        Vector3 offset = Vector3({ 0, -thickness / 2.0f, -thickness / 2.0f });
-        Vector3 center = (m_size * Vector3({ 0, -0.5f, -0.5f })) - offset;
-        renderer->drawBox(center, Vector3({ m_size.x(), thickness, thickness }), Quaternion(), color, false);
-    }
+    // TODO: ワイヤーフレーム化
+    renderer->drawBox(Vector3({ 0, 0, 0 }), m_size, Quaternion(), color, false);
 
     for (const auto& c : m_children) {
         c->draw(shared_from_this(), renderer, blendColor, blendRate);

--- a/src/App/lib/Common/Graphics/Node.cpp
+++ b/src/App/lib/Common/Graphics/Node.cpp
@@ -106,15 +106,6 @@ void Node::setLocalRotation(const Vector3& localRotation)
     m_localRotation = localRotation;
 }
 Vector3 Node::getLocalRotation() const { return m_localRotation; }
-Matrix Node::getGlobalRotation() const
-{
-    Matrix m = Quaternion::toMatrix(Quaternion::angleAxis(m_localRotation.x(), Vector3({ 1, 0, 0 })) * Quaternion::angleAxis(m_localRotation.y(), Vector3({ 0, 1, 0 })) * Quaternion::angleAxis(m_localRotation.z(), Vector3({ 0, 0, 1 })));
-    auto sp = m_parent.lock();
-    if (sp) {
-        return m * sp->getGlobalRotation();
-    }
-    return m;
-}
 
 void Node::setSize(const Vector3& size)
 {
@@ -142,6 +133,19 @@ Matrix Node::computeGlobalTransform()
         return getLocalTransform() * sp->getGlobalTransform();
     }
     return getLocalTransform();
+}
+Matrix Node::getGlobalRotation() const
+{
+    return m_globalRotation;
+}
+Matrix Node::computeGlobalRotation()
+{
+    Matrix m = Quaternion::toMatrix(Quaternion::angleAxis(m_localRotation.x(), Vector3({ 1, 0, 0 })) * Quaternion::angleAxis(m_localRotation.y(), Vector3({ 0, 1, 0 })) * Quaternion::angleAxis(m_localRotation.z(), Vector3({ 0, 0, 1 })));
+    auto sp = m_parent.lock();
+    if (sp) {
+        return m * sp->getGlobalRotation();
+    }
+    return m;
 }
 std::array<Vector3, 8> Node::getEdges() const { return m_edges; }
 std::array<Vector3, 8> Node::computeEdges()
@@ -266,6 +270,8 @@ Node::Node()
     , m_size()
     , m_color()
     , m_localTransform()
+    , m_globalTransform()
+    , m_globalRotation()
     , m_isInvalid(true)
     , m_parent()
     , m_children()

--- a/src/App/lib/Common/Graphics/Telop.cpp
+++ b/src/App/lib/Common/Graphics/Telop.cpp
@@ -61,14 +61,14 @@ void Telop::draw(const std::shared_ptr<FontMap>& fontMap, const std::shared_ptr<
         uCamera.viewMatrix = Matrix();
         uCamera.projectionMatrix = Camera::getOrthoMatrix();
         // ub->setVS(0, &uCamera);
-        surface->setVS(ub, 0, &uCamera);
+        surface->uniformVS(ub, 0, &uCamera);
 
         Reflect::UVector4 uColor;
         uColor.value = Vector4(color, 1.0f - (m_elapsed / duration));
         // ub->setVS(1, &uColor);
-        surface->setVS(ub, 1, &uColor);
+        surface->uniformVS(ub, 1, &uColor);
         // ub->setPS(0, fontSprite->texture);
-        surface->setPS(ub, 0, fontSprite->texture);
+        surface->uniformPS(ub, 0, fontSprite->texture);
         surface->render(rc, ub, vertexBuffer, indexBuffer, indexLength);
         screenX += fontSprite->metrics.size.x();
     }

--- a/src/App/lib/Common/Graphics/Telop.cpp
+++ b/src/App/lib/Common/Graphics/Telop.cpp
@@ -60,14 +60,11 @@ void Telop::draw(const std::shared_ptr<FontMap>& fontMap, const std::shared_ptr<
         uCamera.modelMatrix = modelMatrix;
         uCamera.viewMatrix = Matrix();
         uCamera.projectionMatrix = Camera::getOrthoMatrix();
-        // ub->setVS(0, &uCamera);
         surface->uniformVS(ub, 0, &uCamera);
 
         Reflect::UVector4 uColor;
         uColor.value = Vector4(color, 1.0f - (m_elapsed / duration));
-        // ub->setVS(1, &uColor);
         surface->uniformVS(ub, 1, &uColor);
-        // ub->setPS(0, fontSprite->texture);
         surface->uniformPS(ub, 0, fontSprite->texture);
         surface->render(rc, ub, vertexBuffer, indexBuffer, indexLength);
         screenX += fontSprite->metrics.size.x();

--- a/src/App/lib/Common/Graphics/Telop.cpp
+++ b/src/App/lib/Common/Graphics/Telop.cpp
@@ -60,12 +60,15 @@ void Telop::draw(const std::shared_ptr<FontMap>& fontMap, const std::shared_ptr<
         uCamera.modelMatrix = modelMatrix;
         uCamera.viewMatrix = Matrix();
         uCamera.projectionMatrix = Camera::getOrthoMatrix();
-        ub->setVS(0, &uCamera);
+        // ub->setVS(0, &uCamera);
+        surface->setVS(ub, 0, &uCamera);
 
         Reflect::UVector4 uColor;
         uColor.value = Vector4(color, 1.0f - (m_elapsed / duration));
-        ub->setVS(1, &uColor);
-        ub->setPS(0, fontSprite->texture);
+        // ub->setVS(1, &uColor);
+        surface->setVS(ub, 1, &uColor);
+        // ub->setPS(0, fontSprite->texture);
+        surface->setPS(ub, 0, fontSprite->texture);
         surface->render(rc, ub, vertexBuffer, indexBuffer, indexLength);
         screenX += fontSprite->metrics.size.x();
     }

--- a/src/App/lib/Scenes/Game/GameScene.cpp
+++ b/src/App/lib/Scenes/Game/GameScene.cpp
@@ -16,7 +16,7 @@ GameScene::GameScene()
     , m_debugPlayer()
     , m_debugEntity()
     , m_aimTexture()
-#if _DEBUG
+#if GAMESCENE_PROFILE
     , m_avgTime()
 #endif
 {
@@ -107,7 +107,7 @@ void GameScene::onDraw2D()
     Common::Graphics::TelopSystem::draw();
     m_renderer->drawSprite(Vector2({ 0, 0 }), Vector2({ 32, 32 }), 0.0f, m_aimTexture, Vector4({ 1, 1, 1, 1 }));
 
-#if _DEBUG
+#if GAMESCENE_PROFILE
     float dt = Time::deltaTime();
     m_avgTime *= 1.0f - k_fpsK;
     m_avgTime += dt * k_fpsK;

--- a/src/App/lib/Scenes/Game/System/Entities/BasicEntity.cpp
+++ b/src/App/lib/Scenes/Game/System/Entities/BasicEntity.cpp
@@ -56,7 +56,7 @@ void BasicEntity::update(Field& field)
     Vector3 newPos = oldPos + delta;
 
     // X軸方向
-    {
+    if (Mathf::abs(m_velocity.x()) > 0) {
         Vector3 offset = delta * Vector3({ 1, 0, 0 });
         m_fuzzyHitCache.clear();
         hitTilesFuzzy(field, offset, m_fuzzyHitCache);
@@ -143,7 +143,7 @@ void BasicEntity::update(Field& field)
     }
 
     // Y軸方向
-    {
+    if (Mathf::abs(m_velocity.y()) > 0) {
         Vector3 offset = delta * Vector3({ 0, 1, 0 });
 
         m_fuzzyHitCache.clear();
@@ -232,7 +232,7 @@ void BasicEntity::update(Field& field)
     }
 
     // Z軸方向
-    {
+    if (Mathf::abs(m_velocity.z()) > 0) {
         Vector3 offset = delta * Vector3({ 0, 0, 1 });
         m_fuzzyHitCache.clear();
         hitTilesFuzzy(field, offset, m_fuzzyHitCache);
@@ -333,7 +333,6 @@ void BasicEntity::update(Field& field)
     m_aabb = saveAABB;
 
     setPosition(newPos);
-    m_node->validate();
 
     if (m_receiveGravity) {
         m_velocity.y() -= Field::k_gravity * dt;
@@ -346,6 +345,7 @@ void BasicEntity::update(Field& field)
     newRot = Vector3({ Mathf::normalizeDegree(newRot.x()), Mathf::normalizeDegree(newRot.y()), Mathf::normalizeDegree(newRot.z()) });
 
     if (m_torque.length() > 0.0f) {
+        m_node->validate();
         markAsDirtyAABB();
         rehashAABB();
 

--- a/src/App/lib/Scenes/Game/System/Entities/BasicEntity.cpp
+++ b/src/App/lib/Scenes/Game/System/Entities/BasicEntity.cpp
@@ -622,30 +622,4 @@ void BasicEntity::hitTilesStrict(Field& field, const std::shared_ptr<Common::Gra
     }
 }
 
-float BasicEntity::alignTile(float a, float tileSize)
-{
-    float tileHalf = tileSize / 2.0f;
-    float d = a / tileSize;
-    if (d > 0.0f) {
-        d = ::floorf(d);
-    } else {
-        d = ::ceilf(d);
-    }
-    float m = ::fmodf(a, tileSize);
-
-    if (::fabs(m) < 0.000001f) {
-        return a;
-    }
-    if (m > 0.0f) {
-        if (m < tileHalf) {
-            return d * tileSize;
-        }
-        return (d * tileSize) + tileSize;
-    } else {
-        if (::fabs(m) < tileHalf) {
-            return d * tileSize;
-        }
-        return (d * tileSize) - tileSize;
-    }
-}
 }

--- a/src/App/lib/Scenes/Game/System/Entity.cpp
+++ b/src/App/lib/Scenes/Game/System/Entity.cpp
@@ -8,18 +8,16 @@ Entity::~Entity() { }
 void Entity::addHitEntity(const std::shared_ptr<Entity>& entity)
 {
     if (!isHitOnEntity(entity)) {
-        m_hitTable.emplace_back(entity);
+        m_hitTable[entity->getUuid()] = entity;
     }
 }
 void Entity::removeHitEntity(const std::shared_ptr<Entity>& entity)
 {
-    auto iter = std::remove(m_hitTable.begin(), m_hitTable.end(), entity);
-    m_hitTable.erase(iter, m_hitTable.end());
+    m_hitTable.erase(entity->getUuid());
 }
 bool Entity::isHitOnEntity(const std::shared_ptr<Entity>& entity) const
 {
-    auto iter = std::find(m_hitTable.begin(), m_hitTable.end(), entity);
-    return iter != m_hitTable.end();
+    return m_hitTable.count(entity->getUuid()) != 0;
 }
 
 bool Entity::damage(const std::shared_ptr<DamageSource>& damageSource)
@@ -75,6 +73,7 @@ void Entity::setRotation(const Vector3& rotation)
 }
 Vector3 Entity::getRotation() const { return m_rotation; }
 
+const uuids::uuid& Entity::getUuid() const { return m_uuid; }
 // protected
 Entity::Entity()
     : m_hitTable()
@@ -82,7 +81,15 @@ Entity::Entity()
     , m_currentHP(10)
     , m_position()
     , m_rotation()
+    , m_uuid()
 {
+    std::random_device rd;
+    auto seedData = std::array<int, std::mt19937::state_size> {};
+    std::generate(std::begin(seedData), std::end(seedData), std::ref(rd));
+    std::seed_seq seedSeq(std::begin(seedData), std::end(seedData));
+    std::mt19937 randomGenerator(seedSeq);
+    uuids::uuid_random_generator uuidGen { randomGenerator };
+    m_uuid = uuidGen();
 }
 void Entity::onDead(const std::shared_ptr<DamageSource>& damageSource)
 {

--- a/src/App/lib/Scenes/Game/System/Field.cpp
+++ b/src/App/lib/Scenes/Game/System/Field.cpp
@@ -168,21 +168,15 @@ void Field::draw3D(const std::shared_ptr<Renderer>& renderer)
         Matrix::scale(Vector3({ k_tileSize, k_tileSize, k_tileSize })));
     uCamera.viewMatrix = Camera::getLookAtMatrix();
     uCamera.projectionMatrix = Camera::getPerspectiveMatrix();
-    // ub->setVS(0, &uCamera);
     surface->uniformVS(ub, 0, &uCamera);
-    // ub->setVS(1, &m_tileTransform);
     surface->uniformVS(ub, 1, &m_tileTransform);
-    // ub->setVS(2, &m_tilePallet);
     surface->uniformVS(ub, 2, &m_tilePallet);
 
     Reflect::UVector3 uCameraPos;
     uCameraPos.value = Camera::getPosition();
-    // ub->setVS(3, &uCameraPos);
     surface->uniformVS(ub, 3, &uCameraPos);
 
-    // ub->setPS(0, m_normalTexture);
     surface->uniformPS(ub, 0, m_normalTexture);
-    // ub->setPS(1, m_borderTexture);
     surface->uniformPS(ub, 1, m_borderTexture);
 #if _DEBUG
     if (m_debugDrawField)

--- a/src/App/lib/Scenes/Game/System/Field.cpp
+++ b/src/App/lib/Scenes/Game/System/Field.cpp
@@ -213,28 +213,6 @@ void Field::draw2D(const std::shared_ptr<Renderer>& renderer)
     }
 }
 
-bool Field::hasBlockAt(int32_t x, int32_t y, int32_t z) const
-{
-    if (x >= k_fieldSizeX || x < 0) {
-        return false;
-    }
-    if (y >= k_fieldSizeY || y < 0) {
-        return false;
-    }
-    if (z >= k_fieldSizeZ || z < 0) {
-        return false;
-    }
-    return true;
-}
-
-int32_t Field::getBlockAt(int32_t x, int32_t y, int32_t z) const
-{
-    if (!hasBlockAt(x, y, z)) {
-        return 1;
-    }
-    return m_blocks[toIndex(x, y, z)];
-}
-
 void Field::setPlayer(const std::shared_ptr<Entities::PlayerEntity>& player) { m_player = player; }
 std::shared_ptr<Entities::PlayerEntity> Field::getPlayer() const { return m_player; }
 

--- a/src/App/lib/Scenes/Game/System/Field.cpp
+++ b/src/App/lib/Scenes/Game/System/Field.cpp
@@ -178,7 +178,7 @@ void Field::draw3D(const std::shared_ptr<Renderer>& renderer)
     Reflect::UVector3 uCameraPos;
     uCameraPos.value = Camera::getPosition();
     // ub->setVS(3, &uCameraPos);
-    surface->setVS(ub, 3, &uCamera);
+    surface->setVS(ub, 3, &uCameraPos);
 
     // ub->setPS(0, m_normalTexture);
     surface->setPS(ub, 0, m_normalTexture);

--- a/src/App/lib/Scenes/Game/System/Field.cpp
+++ b/src/App/lib/Scenes/Game/System/Field.cpp
@@ -169,21 +169,21 @@ void Field::draw3D(const std::shared_ptr<Renderer>& renderer)
     uCamera.viewMatrix = Camera::getLookAtMatrix();
     uCamera.projectionMatrix = Camera::getPerspectiveMatrix();
     // ub->setVS(0, &uCamera);
-    surface->setVS(ub, 0, &uCamera);
+    surface->uniformVS(ub, 0, &uCamera);
     // ub->setVS(1, &m_tileTransform);
-    surface->setVS(ub, 1, &m_tileTransform);
+    surface->uniformVS(ub, 1, &m_tileTransform);
     // ub->setVS(2, &m_tilePallet);
-    surface->setVS(ub, 2, &m_tilePallet);
+    surface->uniformVS(ub, 2, &m_tilePallet);
 
     Reflect::UVector3 uCameraPos;
     uCameraPos.value = Camera::getPosition();
     // ub->setVS(3, &uCameraPos);
-    surface->setVS(ub, 3, &uCameraPos);
+    surface->uniformVS(ub, 3, &uCameraPos);
 
     // ub->setPS(0, m_normalTexture);
-    surface->setPS(ub, 0, m_normalTexture);
+    surface->uniformPS(ub, 0, m_normalTexture);
     // ub->setPS(1, m_borderTexture);
-    surface->setPS(ub, 1, m_borderTexture);
+    surface->uniformPS(ub, 1, m_borderTexture);
 #if _DEBUG
     if (m_debugDrawField)
 #endif

--- a/src/App/lib/Scenes/Game/System/Field.cpp
+++ b/src/App/lib/Scenes/Game/System/Field.cpp
@@ -158,6 +158,7 @@ void Field::onGui()
 }
 void Field::draw3D(const std::shared_ptr<Renderer>& renderer)
 {
+    auto surface = Engine::getInstance()->getDevice()->getSurface();
     auto rc = RenderContext::get(Metadata::ProgramTable::TileInstance3D);
     auto ub = UniformPool::rent(Metadata::ProgramTable::TileInstance3D);
     Reflect::UCamera uCamera;
@@ -167,16 +168,22 @@ void Field::draw3D(const std::shared_ptr<Renderer>& renderer)
         Matrix::scale(Vector3({ k_tileSize, k_tileSize, k_tileSize })));
     uCamera.viewMatrix = Camera::getLookAtMatrix();
     uCamera.projectionMatrix = Camera::getPerspectiveMatrix();
-    ub->setVS(0, &uCamera);
-    ub->setVS(1, &m_tileTransform);
-    ub->setVS(2, &m_tilePallet);
+    // ub->setVS(0, &uCamera);
+    surface->setVS(ub, 0, &uCamera);
+    // ub->setVS(1, &m_tileTransform);
+    surface->setVS(ub, 1, &m_tileTransform);
+    // ub->setVS(2, &m_tilePallet);
+    surface->setVS(ub, 2, &m_tilePallet);
 
     Reflect::UVector3 uCameraPos;
     uCameraPos.value = Camera::getPosition();
-    ub->setVS(3, &uCameraPos);
+    // ub->setVS(3, &uCameraPos);
+    surface->setVS(ub, 3, &uCamera);
 
-    ub->setPS(0, m_normalTexture);
-    ub->setPS(1, m_borderTexture);
+    // ub->setPS(0, m_normalTexture);
+    surface->setPS(ub, 0, m_normalTexture);
+    // ub->setPS(1, m_borderTexture);
+    surface->setPS(ub, 1, m_borderTexture);
 #if _DEBUG
     if (m_debugDrawField)
 #endif
@@ -192,7 +199,6 @@ void Field::draw3D(const std::shared_ptr<Renderer>& renderer)
     }
     m_player->draw3D(renderer);
 
-    auto surface = Engine::getInstance()->getDevice()->getSurface();
     surface->beginBatch(RenderContext::get(Metadata::MeshColor3D));
     for (auto& entity : m_entities) {
         entity->draw3D(renderer);

--- a/src/App/lib/Scenes/Game/System/Field.cpp
+++ b/src/App/lib/Scenes/Game/System/Field.cpp
@@ -191,9 +191,13 @@ void Field::draw3D(const std::shared_ptr<Renderer>& renderer)
             m_instanceCount);
     }
     m_player->draw3D(renderer);
+
+    auto surface = Engine::getInstance()->getDevice()->getSurface();
+    surface->beginBatch(RenderContext::get(Metadata::MeshColor3D));
     for (auto& entity : m_entities) {
         entity->draw3D(renderer);
     }
+    surface->endBatch(RenderContext::get(Metadata::MeshColor3D));
 }
 void Field::draw2D(const std::shared_ptr<Renderer>& renderer)
 {

--- a/src/App/lib/Scenes/Game/System/Field.cpp
+++ b/src/App/lib/Scenes/Game/System/Field.cpp
@@ -65,7 +65,7 @@ void Field::generate()
     for (int32_t x = 0; x < k_fieldSizeX; x++) {
         for (int32_t y = 0; y < k_fieldSizeY; y++) {
             for (int32_t z = 0; z < k_fieldSizeZ; z++) {
-                m_blocks[x][y][z] = 0;
+                m_blocks[toIndex(x, y, z)] = 0;
             }
         }
     }
@@ -73,7 +73,7 @@ void Field::generate()
         int32_t x = static_cast<int32_t>(instance.x());
         int32_t y = static_cast<int32_t>(instance.y());
         int32_t z = static_cast<int32_t>(instance.z());
-        m_blocks[x][y][z] = 1;
+        m_blocks[toIndex(x, y, z)] = 1;
     }
 }
 
@@ -232,7 +232,7 @@ int32_t Field::getBlockAt(int32_t x, int32_t y, int32_t z) const
     if (!hasBlockAt(x, y, z)) {
         return 1;
     }
-    return m_blocks[x][y][z];
+    return m_blocks[toIndex(x, y, z)];
 }
 
 void Field::setPlayer(const std::shared_ptr<Entities::PlayerEntity>& player) { m_player = player; }

--- a/src/App/lib/main.cpp
+++ b/src/App/lib/main.cpp
@@ -45,9 +45,9 @@ static int appMain(int argc, char* argv[])
         running = window->peekMessage();
         inputSystem->sync();
 
+        surface->beginPresent();
         sceneManager->onUpdate();
-
-        surface->present();
+        surface->endPresent();
 
         surface->beginGui();
         // sceneManager->onGui();

--- a/src/App/lib/main.cpp
+++ b/src/App/lib/main.cpp
@@ -32,7 +32,7 @@ static int appMain(int argc, char* argv[])
     sceneMap.insert_or_assign("Game", std::make_shared<Game::GameScene>());
     sceneMap.insert_or_assign("Demo", std::make_shared<Demo::DemoScene>());
     sceneMap.insert_or_assign("Debug", std::make_shared<Debug::DebugScene>());
-    std::unique_ptr<SceneManager> sceneManager = std::make_unique<SceneManager>(sceneMap, "Debug");
+    std::unique_ptr<SceneManager> sceneManager = std::make_unique<SceneManager>(sceneMap, "Game");
 
     Graphics::NodeRegistry::initialize();
     Graphics::ParticleSystem::initialize();
@@ -47,6 +47,8 @@ static int appMain(int argc, char* argv[])
 
         sceneManager->onUpdate();
 
+        surface->present();
+
         surface->beginGui();
         // sceneManager->onGui();
         surface->endGui();
@@ -58,8 +60,6 @@ static int appMain(int argc, char* argv[])
         surface->begin2D();
         sceneManager->onDraw2D();
         surface->end2D();
-
-        surface->present();
         Time::end();
         Time::sync();
     }

--- a/src/App/lib/main.cpp
+++ b/src/App/lib/main.cpp
@@ -48,7 +48,7 @@ static int appMain(int argc, char* argv[])
         sceneManager->onUpdate();
 
         surface->beginGui();
-        sceneManager->onGui();
+        // sceneManager->onGui();
         surface->endGui();
 
         surface->begin3D();

--- a/src/App/lib/main.cpp
+++ b/src/App/lib/main.cpp
@@ -32,7 +32,7 @@ static int appMain(int argc, char* argv[])
     sceneMap.insert_or_assign("Game", std::make_shared<Game::GameScene>());
     sceneMap.insert_or_assign("Demo", std::make_shared<Demo::DemoScene>());
     sceneMap.insert_or_assign("Debug", std::make_shared<Debug::DebugScene>());
-    std::unique_ptr<SceneManager> sceneManager = std::make_unique<SceneManager>(sceneMap, "Game");
+    std::unique_ptr<SceneManager> sceneManager = std::make_unique<SceneManager>(sceneMap, "Debug");
 
     Graphics::NodeRegistry::initialize();
     Graphics::ParticleSystem::initialize();

--- a/src/App/lib/main.cpp
+++ b/src/App/lib/main.cpp
@@ -50,7 +50,7 @@ static int appMain(int argc, char* argv[])
         surface->endPresent();
 
         surface->beginGui();
-        // sceneManager->onGui();
+        sceneManager->onGui();
         surface->endGui();
 
         surface->begin3D();

--- a/src/App/mod/Graphics/include/Graphics/MatrixStack.hpp
+++ b/src/App/mod/Graphics/include/Graphics/MatrixStack.hpp
@@ -9,10 +9,12 @@ public:
     void push(const Math::Matrix& m);
     Math::Matrix top() const;
     void pop();
-    Math::Matrix mult() const;
+    Math::Matrix mult();
     void clear();
 
 private:
     std::vector<Math::Matrix> m_stack;
+    Math::Matrix m_mult;
+    bool m_multDirty;
 };
 }

--- a/src/App/mod/Graphics/include/Graphics/RenderContext.hpp
+++ b/src/App/mod/Graphics/include/Graphics/RenderContext.hpp
@@ -13,6 +13,9 @@ class RenderContext {
 public:
     static std::shared_ptr<RenderContext> get(Metadata::ProgramTable entry);
 
+    void beginBatch();
+    void endBatch();
+
 #if SOLID_ENABLE_INTERNAL
     void compute(
         const Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>& cmdList,
@@ -57,6 +60,9 @@ private:
 
     Microsoft::WRL::ComPtr<ID3D12PipelineState> m_computePipelineState;
     Microsoft::WRL::ComPtr<ID3D12RootSignature> m_computeRootSignature;
+
+    bool m_batchMode;
+    bool m_batchInit;
 
     void render(
         const Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>& cmdList,

--- a/src/App/mod/Graphics/include/Graphics/Renderer.hpp
+++ b/src/App/mod/Graphics/include/Graphics/Renderer.hpp
@@ -70,7 +70,7 @@ private:
     void initBoxLine();
     void initBoxTexture();
 
-    Math::Matrix applyMatrix(const Math::Matrix& m) const;
+    Math::Matrix applyMatrix(const Math::Matrix& m);
     void renderObject(const Object& object, const std::shared_ptr<UniformBuffer>& ub);
 
     // common

--- a/src/App/mod/Graphics/include/Graphics/Surface.hpp
+++ b/src/App/mod/Graphics/include/Graphics/Surface.hpp
@@ -111,10 +111,10 @@ private:
     class RenderCommand1;
     class RenderCommand2;
     class RenderCommand3;
-    class UpdateVSCommand;
-    class UpdateGSCommand;
-    class UpdatePSCommand;
-    class UpdateCSCommand;
+    class UniformVSCommand;
+    class UniformGSCommand;
+    class UniformPSCommand;
+    class UniformCSCommand;
 
     std::unique_ptr<std::thread> m_thread;
     std::shared_ptr<Swapchain> m_swapchain;

--- a/src/App/mod/Graphics/include/Graphics/Surface.hpp
+++ b/src/App/mod/Graphics/include/Graphics/Surface.hpp
@@ -34,7 +34,8 @@ public:
     void beginBatch(const std::shared_ptr<RenderContext>& rc);
     void endBatch(const std::shared_ptr<RenderContext>& rc);
 
-    void present();
+    void beginPresent();
+    void endPresent();
 
     void sync(const std::shared_ptr<DualBuffer>& dualBuffer);
 

--- a/src/App/mod/Graphics/include/Graphics/Surface.hpp
+++ b/src/App/mod/Graphics/include/Graphics/Surface.hpp
@@ -31,6 +31,9 @@ public:
     void begin2D();
     void end2D();
 
+    void beginBatch(const std::shared_ptr<RenderContext>& rc);
+    void endBatch(const std::shared_ptr<RenderContext>& rc);
+
     void present();
 
     void sync(const std::shared_ptr<DualBuffer>& dualBuffer);
@@ -90,6 +93,8 @@ private:
     class End3DCommand;
     class Begin2DCommand;
     class End2DCommand;
+    class BeginBatchCommand;
+    class EndBatchCommand;
     class PresentCommand;
     class SyncCommand;
     class RenderCommand1;

--- a/src/App/mod/Graphics/include/Graphics/Surface.hpp
+++ b/src/App/mod/Graphics/include/Graphics/Surface.hpp
@@ -18,6 +18,8 @@ class TileBatch;
 class RenderContext;
 class UniformBuffer;
 class DualBuffer;
+class GpuBuffer;
+class Texture;
 class Surface {
 public:
     ~Surface();
@@ -38,6 +40,14 @@ public:
     void endPresent();
 
     void sync(const std::shared_ptr<DualBuffer>& dualBuffer);
+
+    void setVS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data);
+    void setGS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data);
+    void setPS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data);
+    void setPS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const std::shared_ptr<Texture>& texture);
+    void setCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data);
+    void setCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const std::shared_ptr<Texture>& texture);
+    void setCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const std::shared_ptr<GpuBuffer>& buffer);
 
     void render(
         const std::shared_ptr<RenderContext>& rc,
@@ -101,6 +111,10 @@ private:
     class RenderCommand1;
     class RenderCommand2;
     class RenderCommand3;
+    class UpdateVSCommand;
+    class UpdateGSCommand;
+    class UpdatePSCommand;
+    class UpdateCSCommand;
 
     std::unique_ptr<std::thread> m_thread;
     std::shared_ptr<Swapchain> m_swapchain;
@@ -116,5 +130,8 @@ private:
     Microsoft::WRL::ComPtr<ID3D12Resource> m_depthBuffer;
     Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_depthStencilViewHeap;
     Microsoft::WRL::ComPtr<ID3D12Fence> m_fence;
+
+    void* m_vram;
+    uint64_t m_vramOffset;
 };
 }

--- a/src/App/mod/Graphics/include/Graphics/Surface.hpp
+++ b/src/App/mod/Graphics/include/Graphics/Surface.hpp
@@ -90,6 +90,7 @@ private:
     class End3DCommand;
     class Begin2DCommand;
     class End2DCommand;
+    class PresentCommand;
     class SyncCommand;
     class RenderCommand1;
     class RenderCommand2;

--- a/src/App/mod/Graphics/include/Graphics/Surface.hpp
+++ b/src/App/mod/Graphics/include/Graphics/Surface.hpp
@@ -78,9 +78,22 @@ private:
 
     void bloomWrite(int32_t index);
     void bloomRead(int32_t index);
+    void threadRun();
 
     class Impl;
     std::shared_ptr<Impl> m_impl;
+
+    class ICommand;
+    class BeginGuiCommand;
+    class EndGuiCommand;
+    class Begin3DCommand;
+    class End3DCommand;
+    class Begin2DCommand;
+    class End2DCommand;
+    class SyncCommand;
+    class RenderCommand1;
+    class RenderCommand2;
+    class RenderCommand3;
 
     std::unique_ptr<std::thread> m_thread;
     std::shared_ptr<Swapchain> m_swapchain;

--- a/src/App/mod/Graphics/include/Graphics/Surface.hpp
+++ b/src/App/mod/Graphics/include/Graphics/Surface.hpp
@@ -93,6 +93,7 @@ private:
     void bloomWrite(int32_t index);
     void bloomRead(int32_t index);
     void threadRun();
+    void threadExit();
 
     class Impl;
     std::shared_ptr<Impl> m_impl;
@@ -115,8 +116,14 @@ private:
     class UniformGSCommand;
     class UniformPSCommand;
     class UniformCSCommand;
+    class WaitCommand;
+    class ExitCommand;
 
     std::unique_ptr<std::thread> m_thread;
+    bool m_threadRunning;
+    std::mutex m_threadSyncMutex;
+    std::condition_variable m_threadSyncCondVar;
+    bool m_threadSyncFlag;
     std::shared_ptr<Swapchain> m_swapchain;
 
     Microsoft::WRL::ComPtr<IDXGIFactory6> m_dxgiFactory;

--- a/src/App/mod/Graphics/include/Graphics/Surface.hpp
+++ b/src/App/mod/Graphics/include/Graphics/Surface.hpp
@@ -137,6 +137,7 @@ private:
     Microsoft::WRL::ComPtr<ID3D12Resource> m_depthBuffer;
     Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_depthStencilViewHeap;
     Microsoft::WRL::ComPtr<ID3D12Fence> m_fence;
+    bool m_sendDrawCall;
 
     void* m_vram;
     uint64_t m_vramOffset;

--- a/src/App/mod/Graphics/include/Graphics/Surface.hpp
+++ b/src/App/mod/Graphics/include/Graphics/Surface.hpp
@@ -5,6 +5,7 @@
 #include <d3d12.h>
 #include <dxgi1_6.h>
 #include <memory>
+#include <thread>
 #include <vector>
 #include <wrl/client.h>
 
@@ -78,6 +79,10 @@ private:
     void bloomWrite(int32_t index);
     void bloomRead(int32_t index);
 
+    class Impl;
+    std::shared_ptr<Impl> m_impl;
+
+    std::unique_ptr<std::thread> m_thread;
     std::shared_ptr<Swapchain> m_swapchain;
 
     Microsoft::WRL::ComPtr<IDXGIFactory6> m_dxgiFactory;

--- a/src/App/mod/Graphics/include/Graphics/Surface.hpp
+++ b/src/App/mod/Graphics/include/Graphics/Surface.hpp
@@ -41,13 +41,13 @@ public:
 
     void sync(const std::shared_ptr<DualBuffer>& dualBuffer);
 
-    void setVS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data);
-    void setGS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data);
-    void setPS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data);
-    void setPS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const std::shared_ptr<Texture>& texture);
-    void setCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data);
-    void setCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const std::shared_ptr<Texture>& texture);
-    void setCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const std::shared_ptr<GpuBuffer>& buffer);
+    void uniformVS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data);
+    void uniformGS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data);
+    void uniformPS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data);
+    void uniformPS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const std::shared_ptr<Texture>& texture);
+    void uniformCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data);
+    void uniformCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const std::shared_ptr<Texture>& texture);
+    void uniformCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const std::shared_ptr<GpuBuffer>& buffer);
 
     void render(
         const std::shared_ptr<RenderContext>& rc,

--- a/src/App/mod/Graphics/include/Graphics/Swapchain.hpp
+++ b/src/App/mod/Graphics/include/Graphics/Swapchain.hpp
@@ -28,7 +28,7 @@ public:
     void clear(const Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>& commandList, D3D12_CPU_DESCRIPTOR_HANDLE dsvHandle);
     void execute(const Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>& commandList);
     void swap(const Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>& commandList);
-    void present(const Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>& commandList);
+    void present();
     void waitSync();
 
     void destroy();

--- a/src/App/mod/Graphics/include/Graphics/Swapchain.hpp
+++ b/src/App/mod/Graphics/include/Graphics/Swapchain.hpp
@@ -29,6 +29,8 @@ public:
     void execute(const Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>& commandList);
     void swap(const Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>& commandList);
     void present();
+    void fence();
+    void signal();
     void waitSync();
 
     void destroy();

--- a/src/App/mod/Graphics/include/Graphics/UniformBuffer.hpp
+++ b/src/App/mod/Graphics/include/Graphics/UniformBuffer.hpp
@@ -10,14 +10,6 @@ class Texture;
 class GpuBuffer;
 class UniformBuffer : public std::enable_shared_from_this<UniformBuffer> {
 public:
-    void setVS(int32_t index, const void* data);
-    void setGS(int32_t index, const void* data);
-    void setPS(int32_t index, const void* data);
-    void setPS(int32_t index, const std::shared_ptr<Texture>& texture);
-    void setCS(int32_t index, const void* data);
-    void setCS(int32_t index, const std::shared_ptr<Texture>& texture);
-    void setCS(int32_t index, const std::shared_ptr<GpuBuffer>& buffer);
-
     std::shared_ptr<UniformBuffer> owned();
     bool isOwned() const;
 
@@ -26,6 +18,14 @@ public:
 #if SOLID_ENABLE_INTERNAL
     static std::shared_ptr<UniformBuffer> create(Metadata::ProgramTable entry);
     void destroy();
+
+    void setVS(int32_t index, const void* data);
+    void setGS(int32_t index, const void* data);
+    void setPS(int32_t index, const void* data);
+    void setPS(int32_t index, const std::shared_ptr<Texture>& texture);
+    void setCS(int32_t index, const void* data);
+    void setCS(int32_t index, const std::shared_ptr<Texture>& texture);
+    void setCS(int32_t index, const std::shared_ptr<GpuBuffer>& buffer);
 
     void reset();
     void beginCompute(const Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>& cmdList);

--- a/src/App/mod/Graphics/lib/Graphics/BloomEffect.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/BloomEffect.cpp
@@ -486,7 +486,7 @@ void BloomEffect::initBlur1(
             float4 result = 0;
             float offset[5] = { -2.0, -1.0, 0.0, 1.0, 2.0 };
             float weight[5] = { 0.1, 0.2, 0.4, 0.2, 0.1 };
-            float2 texelSize = float2(1.0 / 800.0, 1.0 / 600.0);
+            float2 texelSize = float2(1.0 / (800.0 / 4.0), 1.0 / (600.0 / 4.0));
 
             for (int i = 0; i < 5; i++)
             {
@@ -727,7 +727,7 @@ void BloomEffect::initBlur2(
             float4 result = 0;
             float offset[5] = { -2.0, -1.0, 0.0, 1.0, 2.0 };
             float weight[5] = { 0.1, 0.2, 0.4, 0.2, 0.1 }; // ガウス分布の重み
-            float2 texelSize = float2(1.0 / 800.0, 1.0 / 600.0);
+            float2 texelSize = float2(1.0 / (800.0 / 4.0), 1.0 / (600.0 / 4.0));
 
             for (int i = 0; i < 5; i++)
             {

--- a/src/App/mod/Graphics/lib/Graphics/Engine.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Engine.cpp
@@ -5,6 +5,7 @@
 #include <Graphics/Screen.hpp>
 #include <Graphics/UniformPool.hpp>
 #include <OS/Window.hpp>
+#include <Utils/Clock.hpp>
 #include <imgui.h>
 #include <stdexcept>
 
@@ -55,6 +56,7 @@ std::shared_ptr<Engine> Engine::startup(int argc, char* argv[])
     m_device = Device::create(m_window);
     RenderContext::initialize();
     UniformPool::initialize();
+    Utils::Clock::initialize();
     return s_instance;
 }
 
@@ -68,6 +70,7 @@ void Engine::shutdown()
     }
     m_shutdowned = true;
 
+    Utils::Clock::destroy();
     UniformPool::destroy();
     RenderContext::destroy();
     FontFactory::destroy();

--- a/src/App/mod/Graphics/lib/Graphics/MatrixStack.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/MatrixStack.cpp
@@ -4,26 +4,44 @@ namespace Lib::Graphics {
 
 MatrixStack::MatrixStack()
     : m_stack()
+    , m_mult()
+    , m_multDirty(true)
 {
 }
 void MatrixStack::push(const Math::Matrix& m)
 {
+    m_multDirty = true;
     m_stack.emplace_back(m);
 }
 Math::Matrix MatrixStack::top() const { return m_stack.back(); }
-void MatrixStack::pop() { m_stack.pop_back(); }
-Math::Matrix MatrixStack::mult() const
+void MatrixStack::pop()
 {
-    Math::Matrix m;
-    auto iter = m_stack.begin();
-    while (iter != m_stack.end()) {
-        m = (*iter) * m;
-        ++iter;
+    m_multDirty = true;
+    m_stack.pop_back();
+
+    if (m_stack.empty()) {
+        m_multDirty = false;
+        m_mult = Math::Matrix();
     }
-    return m;
+}
+Math::Matrix MatrixStack::mult()
+{
+    if (m_multDirty) {
+        Math::Matrix m;
+        auto iter = m_stack.begin();
+        while (iter != m_stack.end()) {
+            m = (*iter) * m;
+            ++iter;
+        }
+        m_mult = m;
+        m_multDirty = false;
+    }
+    return m_mult;
 }
 void MatrixStack::clear()
 {
     m_stack.clear();
+    m_multDirty = false;
+    m_mult = Math::Matrix();
 }
 }

--- a/src/App/mod/Graphics/lib/Graphics/Renderer.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Renderer.cpp
@@ -101,14 +101,14 @@ void Renderer::drawSprite(const Math::Vector2& position, const Math::Vector2& si
     uCamera.viewMatrix = Math::Matrix();
     uCamera.projectionMatrix = Camera::getOrthoMatrix();
     // ub->setVS(0, &uCamera);
-    surface->setVS(ub, 0, &uCamera);
+    surface->uniformVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
     // ub->setVS(1, &uColor);
-    surface->setVS(ub, 1, &uColor);
+    surface->uniformVS(ub, 1, &uColor);
     // ub->setPS(0, texture);
-    surface->setPS(ub, 0, texture);
+    surface->uniformPS(ub, 0, texture);
     renderObject(m_spriteObject, ub);
 }
 
@@ -157,14 +157,14 @@ void Renderer::drawText(const Math::Vector2& position, TextAlignX alignX, TextAl
         uCamera.viewMatrix = Math::Matrix();
         uCamera.projectionMatrix = Camera::getOrthoMatrix();
         // ub->setVS(0, &uCamera);
-        surface->setVS(ub, 0, &uCamera);
+        surface->uniformVS(ub, 0, &uCamera);
 
         Reflect::UVector4 uColor;
         uColor.value = color;
         // ub->setVS(1, &uColor);
-        surface->setVS(ub, 1, &uColor);
+        surface->uniformVS(ub, 1, &uColor);
         // ub->setPS(0, fontSprite->texture);
-        surface->setPS(ub, 0, fontSprite->texture);
+        surface->uniformPS(ub, 0, fontSprite->texture);
         renderObject(m_textObject, ub);
         offset.x() += fontSprite->metrics.advance.x() >> 6;
     }
@@ -279,12 +279,12 @@ void Renderer::drawBox(const Math::Vector3& position, const Math::Vector3& scale
     uCamera.viewMatrix = Camera::getLookAtMatrix();
     uCamera.projectionMatrix = Camera::getPerspectiveMatrix();
     // ub->setVS(0, &uCamera);
-    surface->setVS(ub, 0, &uCamera);
+    surface->uniformVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
     // ub->setVS(1, &uColor);
-    surface->setVS(ub, 1, &uColor);
+    surface->uniformVS(ub, 1, &uColor);
     renderObject(obj, ub);
 }
 

--- a/src/App/mod/Graphics/lib/Graphics/Renderer.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Renderer.cpp
@@ -59,12 +59,10 @@ void Renderer::drawRect(const Math::Vector2& position, const Math::Vector2& size
     uCamera.modelMatrix = modelMatrix;
     uCamera.viewMatrix = Math::Matrix();
     uCamera.projectionMatrix = Camera::getOrthoMatrix();
-    // ub->setVS(0, &uCamera);
     surface->uniformVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
-    // ub->setVS(1, &uColor);
     surface->uniformVS(ub, 1, &uColor);
 
     renderObject(m_rectObject, ub);
@@ -83,12 +81,10 @@ void Renderer::drawCircle(const Math::Vector2& position, const Math::Vector2& si
     uCamera.modelMatrix = modelMatrix;
     uCamera.viewMatrix = Math::Matrix();
     uCamera.projectionMatrix = Camera::getOrthoMatrix();
-    // ub->setVS(0, &uCamera);
     surface->uniformVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
-    // ub->setVS(1, &uColor);
     surface->uniformVS(ub, 1, &uColor);
     renderObject(m_circleObject, ub);
 }
@@ -106,14 +102,11 @@ void Renderer::drawSprite(const Math::Vector2& position, const Math::Vector2& si
     uCamera.modelMatrix = modelMatrix;
     uCamera.viewMatrix = Math::Matrix();
     uCamera.projectionMatrix = Camera::getOrthoMatrix();
-    // ub->setVS(0, &uCamera);
     surface->uniformVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
-    // ub->setVS(1, &uColor);
     surface->uniformVS(ub, 1, &uColor);
-    // ub->setPS(0, texture);
     surface->uniformPS(ub, 0, texture);
     renderObject(m_spriteObject, ub);
 }
@@ -162,14 +155,11 @@ void Renderer::drawText(const Math::Vector2& position, TextAlignX alignX, TextAl
         uCamera.modelMatrix = modelMatrix;
         uCamera.viewMatrix = Math::Matrix();
         uCamera.projectionMatrix = Camera::getOrthoMatrix();
-        // ub->setVS(0, &uCamera);
         surface->uniformVS(ub, 0, &uCamera);
 
         Reflect::UVector4 uColor;
         uColor.value = color;
-        // ub->setVS(1, &uColor);
         surface->uniformVS(ub, 1, &uColor);
-        // ub->setPS(0, fontSprite->texture);
         surface->uniformPS(ub, 0, fontSprite->texture);
         renderObject(m_textObject, ub);
         offset.x() += fontSprite->metrics.advance.x() >> 6;
@@ -211,12 +201,10 @@ void Renderer::drawPlane(const Math::Vector3& position, const Math::Vector2& sca
     uCamera.modelMatrix = modelMatrix;
     uCamera.viewMatrix = Camera::getLookAtMatrix();
     uCamera.projectionMatrix = Camera::getPerspectiveMatrix();
-    // ub->setVS(0, &uCamera);
     surface->uniformVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
-    // ub->setVS(1, &uColor);
     surface->uniformVS(ub, 1, &uColor);
     renderObject(obj, ub);
 }
@@ -234,25 +222,20 @@ void Renderer::drawPlaneLine(const Math::Vector3& position, const Math::Vector2&
     uCamera.modelMatrix = modelMatrix;
     uCamera.viewMatrix = Camera::getLookAtMatrix();
     uCamera.projectionMatrix = Camera::getPerspectiveMatrix();
-    // ub->setVS(0, &uCamera);
     surface->uniformVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
-    // ub->setVS(1, &uColor);
     surface->uniformVS(ub, 1, &uColor);
 
-    // ub->setGS(0, &uCamera);
     surface->uniformGS(ub, 0, &uCamera);
 
     Reflect::UFloat uLineWidth;
     uLineWidth.value = lineWidth;
-    // ub->setGS(1, &uLineWidth);
     surface->uniformGS(ub, 1, &uLineWidth);
 
     Reflect::UVector3 uCameraPosition;
     uCameraPosition.value = Camera::getPosition();
-    // ub->setGS(2, &uCameraPosition);
     surface->uniformGS(ub, 2, &uCameraPosition);
     renderObject(m_planeLineObject, ub);
 }
@@ -270,15 +253,12 @@ void Renderer::drawPlaneTexture(const Math::Vector3& position, const Math::Vecto
     uCamera.modelMatrix = modelMatrix;
     uCamera.viewMatrix = Camera::getLookAtMatrix();
     uCamera.projectionMatrix = Camera::getPerspectiveMatrix();
-    // ub->setVS(0, &uCamera);
     surface->uniformVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
-    // ub->setVS(1, &uColor);
     surface->uniformVS(ub, 1, &uColor);
 
-    // ub->setPS(0, texture);
     surface->uniformPS(ub, 0, texture);
     renderObject(m_planeTextureObject, ub);
 }
@@ -297,12 +277,10 @@ void Renderer::drawBox(const Math::Vector3& position, const Math::Vector3& scale
     uCamera.modelMatrix = modelMatrix;
     uCamera.viewMatrix = Camera::getLookAtMatrix();
     uCamera.projectionMatrix = Camera::getPerspectiveMatrix();
-    // ub->setVS(0, &uCamera);
     surface->uniformVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
-    // ub->setVS(1, &uColor);
     surface->uniformVS(ub, 1, &uColor);
     renderObject(obj, ub);
 }
@@ -320,25 +298,20 @@ void Renderer::drawBoxLine(const Math::Vector3& position, const Math::Vector3& s
     uCamera.modelMatrix = modelMatrix;
     uCamera.viewMatrix = Camera::getLookAtMatrix();
     uCamera.projectionMatrix = Camera::getPerspectiveMatrix();
-    // ub->setVS(0, &uCamera);
     surface->uniformVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
-    // ub->setVS(1, &uColor);
     surface->uniformVS(ub, 1, &uColor);
 
-    // ub->setGS(0, &uCamera);
     surface->uniformGS(ub, 0, &uCamera);
 
     Reflect::UFloat uLineWidth;
     uLineWidth.value = lineWidth;
-    // ub->setGS(1, &uLineWidth);
     surface->uniformGS(ub, 1, &uLineWidth);
 
     Reflect::UVector3 uCameraPosition;
     uCameraPosition.value = Camera::getPosition();
-    // ub->setGS(2, &uCameraPosition);
     surface->uniformGS(ub, 2, &uCameraPosition);
     renderObject(m_boxLineObject, ub);
 }
@@ -356,15 +329,12 @@ void Renderer::drawBoxTexture(const Math::Vector3& position, const Math::Vector3
     uCamera.modelMatrix = modelMatrix;
     uCamera.viewMatrix = Camera::getLookAtMatrix();
     uCamera.projectionMatrix = Camera::getPerspectiveMatrix();
-    // ub->setVS(0, &uCamera);
     surface->uniformVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
-    // ub->setVS(1, &uColor);
     surface->uniformVS(ub, 1, &uColor);
 
-    // ub->setPS(0, texture);
     surface->uniformPS(ub, 0, texture);
     renderObject(m_boxTextureObject, ub);
 }

--- a/src/App/mod/Graphics/lib/Graphics/Renderer.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Renderer.cpp
@@ -49,6 +49,7 @@ void Renderer::textFontSize(int32_t fontSize) { m_fontSize = fontSize; }
 void Renderer::drawRect(const Math::Vector2& position, const Math::Vector2& size, float degree, const Color& color)
 {
     initRect();
+    auto surface = Engine::getInstance()->getDevice()->getSurface();
     auto ub = UniformPool::rent(Metadata::ProgramTable::Color2D);
     auto modelMatrix = applyMatrix(Math::Matrix::transform(
         Math::Matrix::translate(Math::Vector3(position, 0)),
@@ -58,11 +59,13 @@ void Renderer::drawRect(const Math::Vector2& position, const Math::Vector2& size
     uCamera.modelMatrix = modelMatrix;
     uCamera.viewMatrix = Math::Matrix();
     uCamera.projectionMatrix = Camera::getOrthoMatrix();
-    ub->setVS(0, &uCamera);
+    // ub->setVS(0, &uCamera);
+    surface->uniformVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
-    ub->setVS(1, &uColor);
+    // ub->setVS(1, &uColor);
+    surface->uniformVS(ub, 1, &uColor);
 
     renderObject(m_rectObject, ub);
 }
@@ -70,6 +73,7 @@ void Renderer::drawRect(const Math::Vector2& position, const Math::Vector2& size
 void Renderer::drawCircle(const Math::Vector2& position, const Math::Vector2& size, const Color& color)
 {
     initCircle();
+    auto surface = Engine::getInstance()->getDevice()->getSurface();
     auto ub = UniformPool::rent(Metadata::ProgramTable::Color2D);
     auto modelMatrix = applyMatrix(Math::Matrix::transform(
         Math::Matrix::translate(Math::Vector3(position, 0)),
@@ -79,11 +83,13 @@ void Renderer::drawCircle(const Math::Vector2& position, const Math::Vector2& si
     uCamera.modelMatrix = modelMatrix;
     uCamera.viewMatrix = Math::Matrix();
     uCamera.projectionMatrix = Camera::getOrthoMatrix();
-    ub->setVS(0, &uCamera);
+    // ub->setVS(0, &uCamera);
+    surface->uniformVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
-    ub->setVS(1, &uColor);
+    // ub->setVS(1, &uColor);
+    surface->uniformVS(ub, 1, &uColor);
     renderObject(m_circleObject, ub);
 }
 
@@ -195,6 +201,7 @@ void Renderer::drawPlane(const Math::Vector3& position, const Math::Vector2& sca
 {
     Object& obj = isWireframe ? m_planeWireframeObject : m_planeObject;
     initPlane(obj, isWireframe);
+    auto surface = Engine::getInstance()->getDevice()->getSurface();
     auto ub = UniformPool::rent(Metadata::ProgramTable::MeshColor3D);
     auto modelMatrix = applyMatrix(Math::Matrix::transform(
         Math::Matrix::translate(position),
@@ -204,17 +211,20 @@ void Renderer::drawPlane(const Math::Vector3& position, const Math::Vector2& sca
     uCamera.modelMatrix = modelMatrix;
     uCamera.viewMatrix = Camera::getLookAtMatrix();
     uCamera.projectionMatrix = Camera::getPerspectiveMatrix();
-    ub->setVS(0, &uCamera);
+    // ub->setVS(0, &uCamera);
+    surface->uniformVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
-    ub->setVS(1, &uColor);
+    // ub->setVS(1, &uColor);
+    surface->uniformVS(ub, 1, &uColor);
     renderObject(obj, ub);
 }
 
 void Renderer::drawPlaneLine(const Math::Vector3& position, const Math::Vector2& scale, const Math::Quaternion& rotation, const Math::Vector4& color, float lineWidth)
 {
     initPlaneLine();
+    auto surface = Engine::getInstance()->getDevice()->getSurface();
     auto ub = UniformPool::rent(Metadata::ProgramTable::MeshLine3D);
     auto modelMatrix = applyMatrix(Math::Matrix::transform(
         Math::Matrix::translate(position),
@@ -224,27 +234,33 @@ void Renderer::drawPlaneLine(const Math::Vector3& position, const Math::Vector2&
     uCamera.modelMatrix = modelMatrix;
     uCamera.viewMatrix = Camera::getLookAtMatrix();
     uCamera.projectionMatrix = Camera::getPerspectiveMatrix();
-    ub->setVS(0, &uCamera);
+    // ub->setVS(0, &uCamera);
+    surface->uniformVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
-    ub->setVS(1, &uColor);
+    // ub->setVS(1, &uColor);
+    surface->uniformVS(ub, 1, &uColor);
 
-    ub->setGS(0, &uCamera);
+    // ub->setGS(0, &uCamera);
+    surface->uniformGS(ub, 0, &uCamera);
 
     Reflect::UFloat uLineWidth;
     uLineWidth.value = lineWidth;
-    ub->setGS(1, &uLineWidth);
+    // ub->setGS(1, &uLineWidth);
+    surface->uniformGS(ub, 1, &uLineWidth);
 
     Reflect::UVector3 uCameraPosition;
     uCameraPosition.value = Camera::getPosition();
-    ub->setGS(2, &uCameraPosition);
+    // ub->setGS(2, &uCameraPosition);
+    surface->uniformGS(ub, 2, &uCameraPosition);
     renderObject(m_planeLineObject, ub);
 }
 
 void Renderer::drawPlaneTexture(const Math::Vector3& position, const Math::Vector2& scale, const Math::Quaternion& rotation, const std::shared_ptr<Texture>& texture, const Math::Vector4& color)
 {
     initPlaneTexture();
+    auto surface = Engine::getInstance()->getDevice()->getSurface();
     auto ub = UniformPool::rent(Metadata::ProgramTable::MeshTexture3D);
     auto modelMatrix = applyMatrix(Math::Matrix::transform(
         Math::Matrix::translate(position),
@@ -254,13 +270,16 @@ void Renderer::drawPlaneTexture(const Math::Vector3& position, const Math::Vecto
     uCamera.modelMatrix = modelMatrix;
     uCamera.viewMatrix = Camera::getLookAtMatrix();
     uCamera.projectionMatrix = Camera::getPerspectiveMatrix();
-    ub->setVS(0, &uCamera);
+    // ub->setVS(0, &uCamera);
+    surface->uniformVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
-    ub->setVS(1, &uColor);
+    // ub->setVS(1, &uColor);
+    surface->uniformVS(ub, 1, &uColor);
 
-    ub->setPS(0, texture);
+    // ub->setPS(0, texture);
+    surface->uniformPS(ub, 0, texture);
     renderObject(m_planeTextureObject, ub);
 }
 
@@ -291,6 +310,7 @@ void Renderer::drawBox(const Math::Vector3& position, const Math::Vector3& scale
 void Renderer::drawBoxLine(const Math::Vector3& position, const Math::Vector3& scale, const Math::Quaternion& rotation, const Math::Vector4& color, float lineWidth)
 {
     initBoxLine();
+    auto surface = Engine::getInstance()->getDevice()->getSurface();
     auto ub = UniformPool::rent(Metadata::ProgramTable::MeshLine3D);
     auto modelMatrix = applyMatrix(Math::Matrix::transform(
         Math::Matrix::translate(position),
@@ -300,27 +320,33 @@ void Renderer::drawBoxLine(const Math::Vector3& position, const Math::Vector3& s
     uCamera.modelMatrix = modelMatrix;
     uCamera.viewMatrix = Camera::getLookAtMatrix();
     uCamera.projectionMatrix = Camera::getPerspectiveMatrix();
-    ub->setVS(0, &uCamera);
+    // ub->setVS(0, &uCamera);
+    surface->uniformVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
-    ub->setVS(1, &uColor);
+    // ub->setVS(1, &uColor);
+    surface->uniformVS(ub, 1, &uColor);
 
-    ub->setGS(0, &uCamera);
+    // ub->setGS(0, &uCamera);
+    surface->uniformGS(ub, 0, &uCamera);
 
     Reflect::UFloat uLineWidth;
     uLineWidth.value = lineWidth;
-    ub->setGS(1, &uLineWidth);
+    // ub->setGS(1, &uLineWidth);
+    surface->uniformGS(ub, 1, &uLineWidth);
 
     Reflect::UVector3 uCameraPosition;
     uCameraPosition.value = Camera::getPosition();
-    ub->setGS(2, &uCameraPosition);
+    // ub->setGS(2, &uCameraPosition);
+    surface->uniformGS(ub, 2, &uCameraPosition);
     renderObject(m_boxLineObject, ub);
 }
 
 void Renderer::drawBoxTexture(const Math::Vector3& position, const Math::Vector3& scale, const Math::Quaternion& rotation, const std::shared_ptr<Texture>& texture, const Math::Vector4& color)
 {
     initBoxTexture();
+    auto surface = Engine::getInstance()->getDevice()->getSurface();
     auto ub = UniformPool::rent(Metadata::ProgramTable::MeshTexture3D);
     auto modelMatrix = applyMatrix(Math::Matrix::transform(
         Math::Matrix::translate(position),
@@ -330,13 +356,16 @@ void Renderer::drawBoxTexture(const Math::Vector3& position, const Math::Vector3
     uCamera.modelMatrix = modelMatrix;
     uCamera.viewMatrix = Camera::getLookAtMatrix();
     uCamera.projectionMatrix = Camera::getPerspectiveMatrix();
-    ub->setVS(0, &uCamera);
+    // ub->setVS(0, &uCamera);
+    surface->uniformVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
-    ub->setVS(1, &uColor);
+    // ub->setVS(1, &uColor);
+    surface->uniformVS(ub, 1, &uColor);
 
-    ub->setPS(0, texture);
+    // ub->setPS(0, texture);
+    surface->uniformPS(ub, 0, texture);
     renderObject(m_boxTextureObject, ub);
 }
 // private

--- a/src/App/mod/Graphics/lib/Graphics/Renderer.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Renderer.cpp
@@ -543,7 +543,7 @@ void Renderer::initBoxTexture()
     m_boxTextureObject.rc = RenderContext::get(Metadata::ProgramTable::MeshTexture3D);
 }
 
-Math::Matrix Renderer::applyMatrix(const Math::Matrix& m) const
+Math::Matrix Renderer::applyMatrix(const Math::Matrix& m)
 {
     return m * m_matrixStack.mult();
 }

--- a/src/App/mod/Graphics/lib/Graphics/Renderer.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Renderer.cpp
@@ -17,7 +17,6 @@
 #include <Graphics/VertexTexCoord2D.hpp>
 #include <Math/Mathf.hpp>
 
-
 namespace Lib::Graphics {
 // public
 Renderer::Renderer()
@@ -91,6 +90,7 @@ void Renderer::drawCircle(const Math::Vector2& position, const Math::Vector2& si
 void Renderer::drawSprite(const Math::Vector2& position, const Math::Vector2& size, float degree, const std::shared_ptr<Texture>& texture, const Color& color)
 {
     initSprite();
+    auto surface = Engine::getInstance()->getDevice()->getSurface();
     auto ub = UniformPool::rent(Metadata::ProgramTable::Texture2D);
     auto modelMatrix = applyMatrix(Math::Matrix::transform(
         Math::Matrix::translate(Math::Vector3(position, 0)),
@@ -100,12 +100,15 @@ void Renderer::drawSprite(const Math::Vector2& position, const Math::Vector2& si
     uCamera.modelMatrix = modelMatrix;
     uCamera.viewMatrix = Math::Matrix();
     uCamera.projectionMatrix = Camera::getOrthoMatrix();
-    ub->setVS(0, &uCamera);
+    // ub->setVS(0, &uCamera);
+    surface->setVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
-    ub->setVS(1, &uColor);
-    ub->setPS(0, texture);
+    // ub->setVS(1, &uColor);
+    surface->setVS(ub, 1, &uColor);
+    // ub->setPS(0, texture);
+    surface->setPS(ub, 0, texture);
     renderObject(m_spriteObject, ub);
 }
 
@@ -115,6 +118,7 @@ void Renderer::drawText(const Math::Vector2& position, TextAlignX alignX, TextAl
         return;
     }
     initText();
+    auto surface = Engine::getInstance()->getDevice()->getSurface();
     Math::Vector2 offset(position);
     Math::Vector2 size = measureText(label, alignY);
     switch (alignX) {
@@ -152,12 +156,15 @@ void Renderer::drawText(const Math::Vector2& position, TextAlignX alignX, TextAl
         uCamera.modelMatrix = modelMatrix;
         uCamera.viewMatrix = Math::Matrix();
         uCamera.projectionMatrix = Camera::getOrthoMatrix();
-        ub->setVS(0, &uCamera);
+        // ub->setVS(0, &uCamera);
+        surface->setVS(ub, 0, &uCamera);
 
         Reflect::UVector4 uColor;
         uColor.value = color;
-        ub->setVS(1, &uColor);
-        ub->setPS(0, fontSprite->texture);
+        // ub->setVS(1, &uColor);
+        surface->setVS(ub, 1, &uColor);
+        // ub->setPS(0, fontSprite->texture);
+        surface->setPS(ub, 0, fontSprite->texture);
         renderObject(m_textObject, ub);
         offset.x() += fontSprite->metrics.advance.x() >> 6;
     }
@@ -261,6 +268,7 @@ void Renderer::drawBox(const Math::Vector3& position, const Math::Vector3& scale
 {
     Object& obj = isWireframe ? m_boxWireframeObject : m_boxObject;
     initBox(obj, isWireframe);
+    auto surface = Engine::getInstance()->getDevice()->getSurface();
     auto ub = UniformPool::rent(Metadata::ProgramTable::MeshColor3D);
     auto modelMatrix = applyMatrix(Math::Matrix::transform(
         Math::Matrix::translate(position),
@@ -270,11 +278,13 @@ void Renderer::drawBox(const Math::Vector3& position, const Math::Vector3& scale
     uCamera.modelMatrix = modelMatrix;
     uCamera.viewMatrix = Camera::getLookAtMatrix();
     uCamera.projectionMatrix = Camera::getPerspectiveMatrix();
-    ub->setVS(0, &uCamera);
+    // ub->setVS(0, &uCamera);
+    surface->setVS(ub, 0, &uCamera);
 
     Reflect::UVector4 uColor;
     uColor.value = color;
-    ub->setVS(1, &uColor);
+    // ub->setVS(1, &uColor);
+    surface->setVS(ub, 1, &uColor);
     renderObject(obj, ub);
 }
 

--- a/src/App/mod/Graphics/lib/Graphics/Surface.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Surface.cpp
@@ -447,17 +447,19 @@ public:
         : m_usedVec()
         , m_freeVec()
     {
+        // TODO: ポインタ解放処理
+        // NOTE: 参照カウントが無視できないコストなのでスマポは使わない
     }
 
-    std::shared_ptr<T> rent()
+    T* rent()
     {
         if (m_freeVec.size() > 0) {
-            std::shared_ptr<T> ub = m_freeVec.back();
+            T* ub = m_freeVec.back();
             m_freeVec.pop_back();
             m_usedVec.emplace_back(ub);
             return ub;
         } else {
-            std::shared_ptr<T> ub = std::make_shared<T>();
+            T* ub = new T();
             m_usedVec.emplace_back(ub);
             return ub;
         }
@@ -474,8 +476,8 @@ public:
     }
 
 private:
-    std::vector<std::shared_ptr<T>> m_usedVec;
-    std::vector<std::shared_ptr<T>> m_freeVec;
+    std::vector<T*> m_usedVec;
+    std::vector<T*> m_freeVec;
 };
 // Impl
 class Surface::Impl {
@@ -484,7 +486,7 @@ public:
         : queue(4096)
     {
     }
-    Utils::BlockingQueue<std::shared_ptr<ICommand>> queue;
+    Utils::BlockingQueue<ICommand*> queue;
     CommandPool<BeginGuiCommand> beginGuiCommandPool;
     CommandPool<EndGuiCommand> endGuiCommandPool;
     CommandPool<Begin3DCommand> begin3DCommandPool;
@@ -1026,7 +1028,7 @@ void Surface::bloomRead(int32_t index)
 void Surface::threadRun()
 {
     while (true) {
-        std::shared_ptr<ICommand> cmd;
+        ICommand* cmd;
         if (m_impl->queue.dequeue(cmd)) {
             cmd->execute(m_commandList);
         }

--- a/src/App/mod/Graphics/lib/Graphics/Surface.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Surface.cpp
@@ -610,7 +610,7 @@ void Surface::sync(const std::shared_ptr<DualBuffer>& dualBuffer)
     m_impl->queue.enqueue(cmd);
 }
 
-void Surface::setVS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data)
+void Surface::uniformVS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data)
 {
     const Metadata::Program& program = Metadata::k_programs.at(ub->getEntry());
     size_t size = program.vsUniforms.at(index).size;
@@ -624,7 +624,7 @@ void Surface::setVS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, con
     cmd->vram = memory;
     m_impl->queue.enqueue(cmd);
 }
-void Surface::setGS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data)
+void Surface::uniformGS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data)
 {
     const Metadata::Program& program = Metadata::k_programs.at(ub->getEntry());
     size_t size = program.gsUniforms.at(index).size;
@@ -638,7 +638,7 @@ void Surface::setGS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, con
     cmd->vram = memory;
     m_impl->queue.enqueue(cmd);
 }
-void Surface::setPS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data)
+void Surface::uniformPS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data)
 {
     const Metadata::Program& program = Metadata::k_programs.at(ub->getEntry());
     size_t size = program.psUniforms.at(index).size;
@@ -653,7 +653,7 @@ void Surface::setPS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, con
     cmd->texture = nullptr;
     m_impl->queue.enqueue(cmd);
 }
-void Surface::setPS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const std::shared_ptr<Texture>& texture)
+void Surface::uniformPS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const std::shared_ptr<Texture>& texture)
 {
     auto cmd = m_impl->updatePSPool.rent();
     cmd->uniformBuffer = ub;
@@ -662,7 +662,7 @@ void Surface::setPS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, con
     cmd->texture = texture;
     m_impl->queue.enqueue(cmd);
 }
-void Surface::setCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data)
+void Surface::uniformCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const void* data)
 {
     const Metadata::Program& program = Metadata::k_programs.at(ub->getEntry());
     size_t size = program.csUniforms.at(index).size;
@@ -678,7 +678,7 @@ void Surface::setCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, con
     cmd->texture = nullptr;
     m_impl->queue.enqueue(cmd);
 }
-void Surface::setCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const std::shared_ptr<Texture>& texture)
+void Surface::uniformCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const std::shared_ptr<Texture>& texture)
 {
     auto cmd = m_impl->updateCSPool.rent();
     cmd->uniformBuffer = ub;
@@ -688,7 +688,7 @@ void Surface::setCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, con
     cmd->texture = texture;
     m_impl->queue.enqueue(cmd);
 }
-void Surface::setCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const std::shared_ptr<GpuBuffer>& buffer)
+void Surface::uniformCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const std::shared_ptr<GpuBuffer>& buffer)
 {
     auto cmd = m_impl->updateCSPool.rent();
     cmd->uniformBuffer = ub;

--- a/src/App/mod/Graphics/lib/Graphics/Surface.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Surface.cpp
@@ -342,8 +342,7 @@ public:
 class Surface::RenderCommand3 : public ICommand {
 public:
     explicit RenderCommand3()
-        : surface(nullptr)
-        , renderContext(nullptr)
+        : renderContext(nullptr)
         , uniformBuffer(nullptr)
         , vertex(nullptr)
         , index(nullptr)
@@ -363,10 +362,9 @@ public:
         uniformBuffer->syncCompute(commandList);
         uniformBuffer->endCompute(commandList);
 
-        surface->render(renderContext, uniformBuffer, vertex, index, indexLength, instanceBuffers, instanceCount);
+        renderContext->render(commandList, uniformBuffer, vertex, index, indexLength, instanceBuffers, instanceCount);
     }
 
-    Surface* surface;
     std::shared_ptr<RenderContext> renderContext;
     std::shared_ptr<UniformBuffer> uniformBuffer;
     std::shared_ptr<IBuffer> vertex;

--- a/src/App/mod/Graphics/lib/Graphics/Surface.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Surface.cpp
@@ -500,10 +500,10 @@ public:
     CommandPool<RenderCommand1> renderCommand1Pool;
     CommandPool<RenderCommand2> renderCommand2Pool;
     CommandPool<RenderCommand3> renderCommand3Pool;
-    CommandPool<UniformVSCommand> updateVSPool;
-    CommandPool<UniformGSCommand> updateGSPool;
-    CommandPool<UniformPSCommand> updatePSPool;
-    CommandPool<UniformCSCommand> updateCSPool;
+    CommandPool<UniformVSCommand> uniformVSPool;
+    CommandPool<UniformGSCommand> uniformGSPool;
+    CommandPool<UniformPSCommand> uniformPSPool;
+    CommandPool<UniformCSCommand> uniformCSPool;
 };
 // public
 Surface::~Surface()
@@ -595,10 +595,10 @@ void Surface::endPresent()
     m_impl->renderCommand1Pool.releaseAll();
     m_impl->renderCommand2Pool.releaseAll();
     m_impl->renderCommand3Pool.releaseAll();
-    m_impl->updateVSPool.releaseAll();
-    m_impl->updateGSPool.releaseAll();
-    m_impl->updatePSPool.releaseAll();
-    m_impl->updateCSPool.releaseAll();
+    m_impl->uniformVSPool.releaseAll();
+    m_impl->uniformGSPool.releaseAll();
+    m_impl->uniformPSPool.releaseAll();
+    m_impl->uniformCSPool.releaseAll();
 
     m_vramOffset = 0;
 }
@@ -618,7 +618,7 @@ void Surface::uniformVS(const std::shared_ptr<UniformBuffer>& ub, int32_t index,
     ::memcpy(memory, data, size);
     m_vramOffset += size;
 
-    auto cmd = m_impl->updateVSPool.rent();
+    auto cmd = m_impl->uniformVSPool.rent();
     cmd->uniformBuffer = ub;
     cmd->index = index;
     cmd->vram = memory;
@@ -632,7 +632,7 @@ void Surface::uniformGS(const std::shared_ptr<UniformBuffer>& ub, int32_t index,
     ::memcpy(memory, data, size);
     m_vramOffset += size;
 
-    auto cmd = m_impl->updateGSPool.rent();
+    auto cmd = m_impl->uniformGSPool.rent();
     cmd->uniformBuffer = ub;
     cmd->index = index;
     cmd->vram = memory;
@@ -646,7 +646,7 @@ void Surface::uniformPS(const std::shared_ptr<UniformBuffer>& ub, int32_t index,
     ::memcpy(memory, data, size);
     m_vramOffset += size;
 
-    auto cmd = m_impl->updatePSPool.rent();
+    auto cmd = m_impl->uniformPSPool.rent();
     cmd->uniformBuffer = ub;
     cmd->index = index;
     cmd->vram = memory;
@@ -655,7 +655,7 @@ void Surface::uniformPS(const std::shared_ptr<UniformBuffer>& ub, int32_t index,
 }
 void Surface::uniformPS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const std::shared_ptr<Texture>& texture)
 {
-    auto cmd = m_impl->updatePSPool.rent();
+    auto cmd = m_impl->uniformPSPool.rent();
     cmd->uniformBuffer = ub;
     cmd->index = index;
     cmd->vram = nullptr;
@@ -670,7 +670,7 @@ void Surface::uniformCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index,
     ::memcpy(memory, data, size);
     m_vramOffset += size;
 
-    auto cmd = m_impl->updateCSPool.rent();
+    auto cmd = m_impl->uniformCSPool.rent();
     cmd->uniformBuffer = ub;
     cmd->index = index;
     cmd->vram = memory;
@@ -680,7 +680,7 @@ void Surface::uniformCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index,
 }
 void Surface::uniformCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const std::shared_ptr<Texture>& texture)
 {
-    auto cmd = m_impl->updateCSPool.rent();
+    auto cmd = m_impl->uniformCSPool.rent();
     cmd->uniformBuffer = ub;
     cmd->index = index;
     cmd->vram = nullptr;
@@ -690,7 +690,7 @@ void Surface::uniformCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index,
 }
 void Surface::uniformCS(const std::shared_ptr<UniformBuffer>& ub, int32_t index, const std::shared_ptr<GpuBuffer>& buffer)
 {
-    auto cmd = m_impl->updateCSPool.rent();
+    auto cmd = m_impl->uniformCSPool.rent();
     cmd->uniformBuffer = ub;
     cmd->index = index;
     cmd->vram = nullptr;

--- a/src/App/mod/Graphics/lib/Graphics/Surface.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Surface.cpp
@@ -13,7 +13,7 @@
 #include <Graphics/VertexTexCoord2D.hpp>
 #include <Graphics/VertexTexCoord3D.hpp>
 #include <Math/Vector.hpp>
-#include <Utils/BlockingQueue.hpp>
+#include <Utils/LockfreeQueue.hpp>
 #include <Utils/Stopwatch.hpp>
 #include <Utils/String.hpp>
 #include <stdexcept>
@@ -526,7 +526,7 @@ public:
         : queue(8192)
     {
     }
-    Utils::BlockingQueue<ICommand*> queue;
+    Utils::LockfreeQueue<ICommand*> queue;
     CommandPool<BeginGuiCommand> beginGuiCommandPool;
     CommandPool<EndGuiCommand> endGuiCommandPool;
     CommandPool<Begin3DCommand> begin3DCommandPool;

--- a/src/App/mod/Graphics/lib/Graphics/Surface.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Surface.cpp
@@ -497,7 +497,7 @@ void Surface::endBatch(const std::shared_ptr<RenderContext>& rc)
     m_impl->queue.enqueue(cmd);
 }
 
-void Surface::present()
+void Surface::beginPresent()
 {
     m_swapchain->fence();
     {
@@ -505,6 +505,10 @@ void Surface::present()
         cmd->surface = this;
         m_impl->queue.enqueue(cmd);
     }
+}
+
+void Surface::endPresent()
+{
     m_swapchain->waitSync();
 
     m_commandAllocator->Reset();

--- a/src/App/mod/Graphics/lib/Graphics/Surface.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Surface.cpp
@@ -379,9 +379,9 @@ public:
     int32_t threadGroupCountZ;
 };
 
-class Surface::UpdateVSCommand : public ICommand {
+class Surface::UniformVSCommand : public ICommand {
 public:
-    explicit UpdateVSCommand() { }
+    explicit UniformVSCommand() { }
     void execute(const Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>& commandList) override
     {
         uniformBuffer->setVS(index, vram);
@@ -391,9 +391,9 @@ public:
     void* vram;
 };
 
-class Surface::UpdateGSCommand : public ICommand {
+class Surface::UniformGSCommand : public ICommand {
 public:
-    explicit UpdateGSCommand() { }
+    explicit UniformGSCommand() { }
     void execute(const Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>& commandList) override
     {
         uniformBuffer->setGS(index, vram);
@@ -403,9 +403,9 @@ public:
     void* vram;
 };
 
-class Surface::UpdatePSCommand : public ICommand {
+class Surface::UniformPSCommand : public ICommand {
 public:
-    explicit UpdatePSCommand() { }
+    explicit UniformPSCommand() { }
     void execute(const Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>& commandList) override
     {
         if (texture) {
@@ -420,9 +420,9 @@ public:
     std::shared_ptr<Texture> texture;
 };
 
-class Surface::UpdateCSCommand : public ICommand {
+class Surface::UniformCSCommand : public ICommand {
 public:
-    explicit UpdateCSCommand() { }
+    explicit UniformCSCommand() { }
     void execute(const Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>& commandList) override
     {
         if (texture) {
@@ -500,10 +500,10 @@ public:
     CommandPool<RenderCommand1> renderCommand1Pool;
     CommandPool<RenderCommand2> renderCommand2Pool;
     CommandPool<RenderCommand3> renderCommand3Pool;
-    CommandPool<UpdateVSCommand> updateVSPool;
-    CommandPool<UpdateGSCommand> updateGSPool;
-    CommandPool<UpdatePSCommand> updatePSPool;
-    CommandPool<UpdateCSCommand> updateCSPool;
+    CommandPool<UniformVSCommand> updateVSPool;
+    CommandPool<UniformGSCommand> updateGSPool;
+    CommandPool<UniformPSCommand> updatePSPool;
+    CommandPool<UniformCSCommand> updateCSPool;
 };
 // public
 Surface::~Surface()

--- a/src/App/mod/Graphics/lib/Graphics/Surface.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Surface.cpp
@@ -776,6 +776,8 @@ void Surface::destroy()
     BloomEffect::destroy();
     m_swapchain->destroy();
     m_swapchain = nullptr;
+    ::free(m_vram);
+    m_vram = nullptr;
 }
 // private
 Surface::Surface()

--- a/src/App/mod/Graphics/lib/Graphics/Surface.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Surface.cpp
@@ -163,8 +163,8 @@ void Surface::end2D()
 
 void Surface::present()
 {
-    m_swapchain->present(m_commandList);
     m_swapchain->waitSync();
+    m_swapchain->present();
 
     m_commandAllocator->Reset();
     m_commandList->Reset(m_commandAllocator.Get(), nullptr);

--- a/src/App/mod/Graphics/lib/Graphics/Surface.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Surface.cpp
@@ -900,8 +900,13 @@ void Surface::init(
         texHeapProps.VisibleNodeMask = 0;
         D3D12_RESOURCE_DESC texResDesc = {};
         texResDesc.Format = DXGI_FORMAT_R16G16B16A16_FLOAT;
-        texResDesc.Width = Screen::getWidth();
-        texResDesc.Height = Screen::getHeight();
+        if (i == 0) {
+            texResDesc.Width = Screen::getWidth();
+            texResDesc.Height = Screen::getHeight();
+        } else {
+            texResDesc.Width = Screen::getWidth() / 4;
+            texResDesc.Height = Screen::getHeight() / 4;
+        }
         texResDesc.DepthOrArraySize = 1;
         texResDesc.SampleDesc.Count = 1;
         texResDesc.SampleDesc.Quality = 0;
@@ -997,8 +1002,13 @@ void Surface::bloomWrite(int32_t index)
 
     // viewport
     D3D12_VIEWPORT viewport = {};
-    viewport.Width = Screen::getWidth();
-    viewport.Height = Screen::getHeight();
+    if (index == 0) {
+        viewport.Width = Screen::getWidth();
+        viewport.Height = Screen::getHeight();
+    } else {
+        viewport.Width = Screen::getWidth() / 4;
+        viewport.Height = Screen::getHeight() / 4;
+    }
     viewport.TopLeftX = 0;
     viewport.TopLeftY = 0;
     viewport.MaxDepth = 1.0f;
@@ -1008,8 +1018,13 @@ void Surface::bloomWrite(int32_t index)
     D3D12_RECT scissorRect = {};
     scissorRect.top = 0;
     scissorRect.left = 0;
-    scissorRect.right = scissorRect.left + Screen::getWidth();
-    scissorRect.bottom = scissorRect.top + Screen::getHeight();
+    if (index == 0) {
+        scissorRect.right = scissorRect.left + Screen::getWidth();
+        scissorRect.bottom = scissorRect.top + Screen::getHeight();
+    } else {
+        scissorRect.right = scissorRect.left + Screen::getWidth() / 4;
+        scissorRect.bottom = scissorRect.top + Screen::getHeight() / 4;
+    }
     m_commandList->RSSetScissorRects(1, &scissorRect);
 }
 

--- a/src/App/mod/Graphics/lib/Graphics/Surface.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Surface.cpp
@@ -481,7 +481,7 @@ private:
 class Surface::Impl {
 public:
     explicit Impl()
-        : queue(1024)
+        : queue(4096)
     {
     }
     Utils::BlockingQueue<std::shared_ptr<ICommand>> queue;

--- a/src/App/mod/Graphics/lib/Graphics/Surface.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Surface.cpp
@@ -41,7 +41,9 @@ public:
 
     void execute(const Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>& commandList) override
     {
-        swapchain->guiClear();
+        // これはメインスレッドで呼ぶのが正しい
+        // ImGui::Renderさえ描画スレッドで呼べばいい
+        // swapchain->guiClear();
     }
 
     std::shared_ptr<Swapchain> swapchain;
@@ -443,9 +445,7 @@ Surface::~Surface()
 
 void Surface::beginGui()
 {
-    auto cmd = m_impl->beginGuiCommandPool.rent();
-    cmd->swapchain = m_swapchain;
-    m_impl->queue.enqueue(cmd);
+    m_swapchain->guiClear();
 }
 
 void Surface::endGui()

--- a/src/App/mod/Graphics/lib/Graphics/Swapchain.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Swapchain.cpp
@@ -114,7 +114,7 @@ void Swapchain::waitSync()
 {
     // Wait events
     m_commandQueue->Signal(m_fence.Get(), ++m_fenceVal);
-    if (m_fence->GetCompletedValue() != m_fenceVal) {
+    if (m_fence->GetCompletedValue() < m_fenceVal) {
         HANDLE evt = CreateEvent(nullptr, false, false, nullptr);
         m_fence->SetEventOnCompletion(m_fenceVal, evt);
         WaitForSingleObject(evt, INFINITE);

--- a/src/App/mod/Graphics/lib/Graphics/Swapchain.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Swapchain.cpp
@@ -105,7 +105,7 @@ void Swapchain::swap(const Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>& co
     commandList->ResourceBarrier(1, &barrier);
 }
 
-void Swapchain::present(const Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList>& commandList)
+void Swapchain::present()
 {
     m_swapchain->Present(1, 0);
 }

--- a/src/App/mod/Graphics/lib/Graphics/Swapchain.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/Swapchain.cpp
@@ -110,10 +110,19 @@ void Swapchain::present()
     m_swapchain->Present(1, 0);
 }
 
+void Swapchain::fence()
+{
+    ++m_fenceVal;
+}
+
+void Swapchain::signal()
+{
+    m_commandQueue->Signal(m_fence.Get(), m_fenceVal);
+}
+
 void Swapchain::waitSync()
 {
     // Wait events
-    m_commandQueue->Signal(m_fence.Get(), ++m_fenceVal);
     if (m_fence->GetCompletedValue() < m_fenceVal) {
         HANDLE evt = CreateEvent(nullptr, false, false, nullptr);
         m_fence->SetEventOnCompletion(m_fenceVal, evt);

--- a/src/App/mod/Graphics/lib/Graphics/UniformBuffer.cpp
+++ b/src/App/mod/Graphics/lib/Graphics/UniformBuffer.cpp
@@ -7,6 +7,29 @@
 namespace Lib::Graphics {
 using Microsoft::WRL::ComPtr;
 // public
+std::shared_ptr<UniformBuffer> UniformBuffer::owned()
+{
+    if (m_owned) {
+        throw std::logic_error("already owned.");
+    }
+    m_owned = true;
+    return shared_from_this();
+}
+bool UniformBuffer::isOwned() const { return m_owned; }
+
+Metadata::ProgramTable UniformBuffer::getEntry() const { return m_entry; }
+// internal
+std::shared_ptr<UniformBuffer> UniformBuffer::create(Metadata::ProgramTable entry)
+{
+    auto ub = std::shared_ptr<UniformBuffer>(new UniformBuffer());
+    ub->init(entry);
+    return ub;
+}
+
+void UniformBuffer::destroy()
+{
+}
+
 void UniformBuffer::setVS(int32_t index, const void* data)
 {
     if (index >= Metadata::k_programs.at(m_entry).vsUniforms.size()) {
@@ -154,29 +177,6 @@ void UniformBuffer::setCS(int32_t index, const std::shared_ptr<GpuBuffer>& buffe
     } else {
         throw std::logic_error("uniform is require buffer.");
     }
-}
-
-std::shared_ptr<UniformBuffer> UniformBuffer::owned()
-{
-    if (m_owned) {
-        throw std::logic_error("already owned.");
-    }
-    m_owned = true;
-    return shared_from_this();
-}
-bool UniformBuffer::isOwned() const { return m_owned; }
-
-Metadata::ProgramTable UniformBuffer::getEntry() const { return m_entry; }
-// internal
-std::shared_ptr<UniformBuffer> UniformBuffer::create(Metadata::ProgramTable entry)
-{
-    auto ub = std::shared_ptr<UniformBuffer>(new UniformBuffer());
-    ub->init(entry);
-    return ub;
-}
-
-void UniformBuffer::destroy()
-{
 }
 
 void UniformBuffer::reset() { m_owned = false; }

--- a/src/App/mod/Graphics/test/CMakeLists.txt
+++ b/src/App/mod/Graphics/test/CMakeLists.txt
@@ -4,7 +4,7 @@ project(Lib-Graphics-Test CXX)
 add_executable(Lib-Graphics-Test main.cpp)
 target_compile_definitions(Lib-Graphics-Test PRIVATE TEST_EMBED_DIR="${TEST_EMBED_DIR}")
 target_compile_options(Lib-Graphics-Test PRIVATE $<$<BOOL:${MSVC}>: /utf-8>)
-target_compile_features(Lib-Graphics-Test PRIVATE cxx_std_17)
+target_compile_features(Lib-Graphics-Test PRIVATE cxx_std_20)
 target_include_directories(
     Lib-Graphics-Test
     PRIVATE

--- a/src/App/mod/Math/include/Math/Mathf.hpp
+++ b/src/App/mod/Math/include/Math/Mathf.hpp
@@ -181,6 +181,18 @@ public:
         return d;
     }
 
+    template <typename T>
+    inline static T fma(T x, T y, T z)
+    {
+        return x * y + z;
+    }
+
+    template <>
+    INLINE_SPEC_STATIC float fma(float x, float y, float z)
+    {
+        return std::fmaf(x, y, z);
+    }
+
 private:
     Mathf() = delete;
     ~Mathf() = delete;

--- a/src/App/mod/Math/include/Math/Matrix.hpp
+++ b/src/App/mod/Math/include/Math/Matrix.hpp
@@ -65,7 +65,7 @@ struct MatrixT {
         return a;
     }
 
-    T& at(int32_t row, int32_t col)
+    inline T& at(int32_t row, int32_t col)
     {
         return components[(row * ColumnNum) + col];
     }
@@ -104,7 +104,7 @@ struct MatrixT {
         return a;
     }
 
-    T at(int32_t row, int32_t col) const
+    inline T at(int32_t row, int32_t col) const
     {
         return components[(row * ColumnNum) + col];
     }

--- a/src/App/mod/Math/include/Math/Matrix.hpp
+++ b/src/App/mod/Math/include/Math/Matrix.hpp
@@ -125,18 +125,11 @@ struct MatrixT {
     static MatrixT<T> multiply(const MatrixT<T>& a, const MatrixT<T>& b)
     {
         MatrixT<T> m;
-        std::array<std::array<T, RowNum>, ColumnNum> columns;
-        for (int32_t row = 0; row < RowNum; row++) {
-            columns[row] = b.column(row);
-        }
-
         for (int32_t i = 0; i < RowNum; i++) {
-            std::array<T, ColumnNum> row = a.row(i);
             for (int32_t j = 0; j < ColumnNum; j++) {
-                std::array<T, RowNum> col = columns[j];
                 T sum = static_cast<T>(0);
                 for (int32_t k = 0; k < RowNum; k++) {
-                    sum += row[k] * col[k];
+                    sum += a.at(i, k) * b.at(k, j);
                 }
                 m.at(i, j) = sum;
             }

--- a/src/App/mod/Math/include/Math/Matrix.hpp
+++ b/src/App/mod/Math/include/Math/Matrix.hpp
@@ -24,9 +24,9 @@ struct MatrixT {
     explicit MatrixT(const std::array<VectorT<T, ColumnNum>, RowNum>& table)
     {
         for (int32_t i = 0; i < RowNum; i++) {
-            const VectorT<T, ColumnNum>& line = table.at(i);
+            const VectorT<T, ColumnNum>& line = table[i];
             for (int32_t j = 0; j < ColumnNum; j++) {
-                this->at(i, j) = line.components.at(j);
+                this->at(i, j) = line.components[j];
             }
         }
     }
@@ -297,10 +297,9 @@ struct MatrixT {
         // see: https://learn.microsoft.com/ja-jp/windows/win32/direct3d9/d3dxmatrixperspectivefovlh
         MatrixT<T> ret;
         T one = static_cast<T>(1);
-        T zero = static_cast<T>(0);
         T yScale = one / Mathf::tan(fovy / static_cast<T>(2) * Mathf::Deg2Rad);
         T xScale = yScale / aspectRatio;
-        std::fill(ret.components.begin(), ret.components.end(), zero);
+        ::memset(ret.components, 0, sizeof(T) * 16);
         ret.at(0, 0) = xScale;
         ret.at(1, 1) = yScale;
         ret.at(2, 2) = zFar / (zFar - zNear);
@@ -403,7 +402,7 @@ struct MatrixT {
         return os;
     }
 
-    std::array<T, RowNum * ColumnNum> components;
+    T components[RowNum * ColumnNum];
 };
 template <typename T>
 bool operator==(const MatrixT<T>& a, const MatrixT<T>& b)

--- a/src/App/mod/Math/include/Math/Matrix.hpp
+++ b/src/App/mod/Math/include/Math/Matrix.hpp
@@ -140,7 +140,8 @@ struct MatrixT {
                 for (int32_t j = 0; j < ColumnNum; j++) {
                     int32_t aIndex = (i * ColumnNum) + k;
                     int32_t bIndex = (k * ColumnNum) + j;
-                    m.components[(i * ColumnNum) + j] = (a.components[aIndex] * b.components[bIndex] + m.components[(i * ColumnNum) + j]);
+                    // m.components[(i * ColumnNum) + j] = (a.components[aIndex] * b.components[bIndex] + m.components[(i * ColumnNum) + j]);
+                    m.components[(i * ColumnNum) + j] = std::fmaf(a.components[aIndex], b.components[bIndex], m.components[(i * ColumnNum) + j]);
                 }
             }
         }

--- a/src/App/mod/Math/include/Math/Matrix.hpp
+++ b/src/App/mod/Math/include/Math/Matrix.hpp
@@ -125,20 +125,25 @@ struct MatrixT {
     static MatrixT<T> multiply(const MatrixT<T>& a, const MatrixT<T>& b)
     {
         MatrixT<T> m;
+        ::memset(m.components, 0, sizeof(T) * 16);
 #ifdef __clang__
-#pragma unroll
+#pragma unroll 4
 #endif
         for (int32_t i = 0; i < RowNum; i++) {
 #ifdef __clang__
-#pragma unroll
+#pragma unroll 4
 #endif
-            for (int32_t j = 0; j < ColumnNum; j++) {
-                T sum = static_cast<T>(0);
-                for (int32_t k = 0; k < RowNum; k++) {
+            for (int32_t k = 0; k < RowNum; k++) {
+#ifdef __clang__
+#pragma unroll 4
+#endif
+                for (int32_t j = 0; j < ColumnNum; j++) {
                     // sum += a.at(i, k) * b.at(k, j);
-                    sum = std::fmaf(a.at(i, k), b.at(k, j), sum);
+                    int32_t aIndex = (i * ColumnNum) + k;
+                    int32_t bIndex = (k * ColumnNum) + j;
+                    m.components[(i * ColumnNum) + j] = (a.components[aIndex] * b.components[bIndex] + m.components[(i * ColumnNum) + j]);
                 }
-                m.at(i, j) = sum;
+                // m.at(i, j) = sum;
             }
         }
         return m;

--- a/src/App/mod/Math/include/Math/Matrix.hpp
+++ b/src/App/mod/Math/include/Math/Matrix.hpp
@@ -138,12 +138,10 @@ struct MatrixT {
 #pragma unroll 4
 #endif
                 for (int32_t j = 0; j < ColumnNum; j++) {
-                    // sum += a.at(i, k) * b.at(k, j);
                     int32_t aIndex = (i * ColumnNum) + k;
                     int32_t bIndex = (k * ColumnNum) + j;
                     m.components[(i * ColumnNum) + j] = (a.components[aIndex] * b.components[bIndex] + m.components[(i * ColumnNum) + j]);
                 }
-                // m.at(i, j) = sum;
             }
         }
         return m;

--- a/src/App/mod/Math/include/Math/Matrix.hpp
+++ b/src/App/mod/Math/include/Math/Matrix.hpp
@@ -141,7 +141,7 @@ struct MatrixT {
                     int32_t aIndex = (i * ColumnNum) + k;
                     int32_t bIndex = (k * ColumnNum) + j;
                     // m.components[(i * ColumnNum) + j] = (a.components[aIndex] * b.components[bIndex] + m.components[(i * ColumnNum) + j]);
-                    m.components[(i * ColumnNum) + j] = std::fmaf(a.components[aIndex], b.components[bIndex], m.components[(i * ColumnNum) + j]);
+                    m.components[(i * ColumnNum) + j] = Mathf::fma(a.components[aIndex], b.components[bIndex], m.components[(i * ColumnNum) + j]);
                 }
             }
         }

--- a/src/App/mod/Math/include/Math/Matrix.hpp
+++ b/src/App/mod/Math/include/Math/Matrix.hpp
@@ -154,12 +154,10 @@ struct MatrixT {
 
     static VectorT<T, 3> multiply(const MatrixT<T>& a, const VectorT<T, 3>& b)
     {
-        std::array<T, ColumnNum> r1 = a.column(0);
-        std::array<T, ColumnNum> r2 = a.column(1);
-        std::array<T, ColumnNum> r3 = a.column(2);
-        return VectorT<T, 3>({ (r1.at(0) * b.at(0)) + (r1.at(1) * b.at(1)) + (r1.at(2) * b.at(2)) + r1.at(3),
-            (r2.at(0) * b.at(0)) + (r2.at(1) * b.at(1)) + (r2.at(2) * b.at(2) + r2.at(3)),
-            (r3.at(0) * b.at(0)) + (r3.at(1) * b.at(1)) + (r3.at(2) * b.at(2)) + r3.at(3) });
+        // TODO: 他の multiply も最適化
+        return VectorT<T, 3>({ (a.at(0, 0) * b.at(0)) + (a.at(1, 0) * b.at(1)) + (a.at(2, 0) * b.at(2)) + a.at(3, 0),
+            (a.at(0, 1) * b.at(0)) + (a.at(1, 1) * b.at(1)) + (a.at(2, 1) * b.at(2) + a.at(3, 1)),
+            (a.at(0, 2) * b.at(0)) + (a.at(1, 2) * b.at(1)) + (a.at(2, 2) * b.at(2)) + a.at(3, 2) });
     }
 
     static VectorT<T, 4> multiply(const MatrixT<T>& a, const VectorT<T, 4>& b)

--- a/src/App/mod/Math/include/Math/Matrix.hpp
+++ b/src/App/mod/Math/include/Math/Matrix.hpp
@@ -129,6 +129,9 @@ struct MatrixT {
 #pragma unroll
 #endif
         for (int32_t i = 0; i < RowNum; i++) {
+#ifdef __clang__
+#pragma unroll
+#endif
             for (int32_t j = 0; j < ColumnNum; j++) {
                 T sum = static_cast<T>(0);
                 for (int32_t k = 0; k < RowNum; k++) {

--- a/src/App/mod/Math/include/Math/Matrix.hpp
+++ b/src/App/mod/Math/include/Math/Matrix.hpp
@@ -407,6 +407,7 @@ struct MatrixT {
         return os;
     }
 
+    // NOTE: _ITERATOR_DEBUG_LEVELや_CONTAINER_DEBUG_LEVELの影響を受けるstd::arrayは使わない
     T components[RowNum * ColumnNum];
 };
 template <typename T>

--- a/src/App/mod/Math/include/Math/Matrix.hpp
+++ b/src/App/mod/Math/include/Math/Matrix.hpp
@@ -125,11 +125,17 @@ struct MatrixT {
     static MatrixT<T> multiply(const MatrixT<T>& a, const MatrixT<T>& b)
     {
         MatrixT<T> m;
+#ifdef _MSC_VER
+#pragma loop(unroll)
+#else
+#pragma unroll
+#endif
         for (int32_t i = 0; i < RowNum; i++) {
             for (int32_t j = 0; j < ColumnNum; j++) {
                 T sum = static_cast<T>(0);
                 for (int32_t k = 0; k < RowNum; k++) {
-                    sum += a.at(i, k) * b.at(k, j);
+                    // sum += a.at(i, k) * b.at(k, j);
+                    sum = std::fmaf(a.at(i, k), b.at(k, j), sum);
                 }
                 m.at(i, j) = sum;
             }

--- a/src/App/mod/Math/include/Math/Matrix.hpp
+++ b/src/App/mod/Math/include/Math/Matrix.hpp
@@ -33,14 +33,14 @@ struct MatrixT {
 
     // mutable
 
-    std::array<std::reference_wrapper<T>, ColumnNum> row(int32_t index)
+    std::array<T&, ColumnNum> row(int32_t index)
     {
         T& e0 = components[(index * ColumnNum) + 0];
         T& e1 = components[(index * ColumnNum) + 1];
         T& e2 = components[(index * ColumnNum) + 2];
         T& e3 = components[(index * ColumnNum) + 3];
 
-        std::array<std::reference_wrapper<T>, 4> a {
+        std::array<T&, 4> a {
             e0,
             e1,
             e2,
@@ -49,14 +49,14 @@ struct MatrixT {
         return a;
     }
 
-    std::array<std::reference_wrapper<T>, RowNum> column(int32_t index)
+    std::array<T&, RowNum> column(int32_t index)
     {
         T& e0 = components[index];
         T& e1 = components[(1 * ColumnNum) + index + 0];
         T& e2 = components[(2 * ColumnNum) + index + 0];
         T& e3 = components[(3 * ColumnNum) + index + 0];
 
-        std::array<std::reference_wrapper<T>, 4> a {
+        std::array<T&, 4> a {
             e0,
             e1,
             e2,
@@ -72,14 +72,14 @@ struct MatrixT {
 
     // immutable
 
-    std::array<std::reference_wrapper<const T>, ColumnNum> row(int32_t index) const
+    std::array<T, ColumnNum> row(int32_t index) const
     {
         const T& e0 = components[(index * ColumnNum) + 0];
         const T& e1 = components[(index * ColumnNum) + 1];
         const T& e2 = components[(index * ColumnNum) + 2];
         const T& e3 = components[(index * ColumnNum) + 3];
 
-        std::array<std::reference_wrapper<const T>, 4> a {
+        std::array<T, 4> a {
             e0,
             e1,
             e2,
@@ -88,14 +88,14 @@ struct MatrixT {
         return a;
     }
 
-    std::array<std::reference_wrapper<const T>, RowNum> column(int32_t index) const
+    std::array<T, RowNum> column(int32_t index) const
     {
         const T& e0 = components[index];
         const T& e1 = components[(1 * ColumnNum) + index + 0];
         const T& e2 = components[(2 * ColumnNum) + index + 0];
         const T& e3 = components[(3 * ColumnNum) + index + 0];
 
-        std::array<std::reference_wrapper<const T>, 4> a {
+        std::array<T, 4> a {
             e0,
             e1,
             e2,
@@ -111,11 +111,11 @@ struct MatrixT {
 
     // operator
 
-    const std::array<std::reference_wrapper<const T>, ColumnNum> operator[](std::size_t i) const
+    const std::array<T, ColumnNum> operator[](std::size_t i) const
     {
         return row(static_cast<int32_t>(i));
     }
-    std::array<std::reference_wrapper<T>, ColumnNum> operator[](std::size_t i)
+    std::array<T&, ColumnNum> operator[](std::size_t i)
     {
         return row(static_cast<int32_t>(i));
     }
@@ -125,10 +125,15 @@ struct MatrixT {
     static MatrixT<T> multiply(const MatrixT<T>& a, const MatrixT<T>& b)
     {
         MatrixT<T> m;
+        std::array<std::array<T, RowNum>, ColumnNum> columns;
+        for (int32_t row = 0; row < RowNum; row++) {
+            columns[row] = b.column(row);
+        }
+
         for (int32_t i = 0; i < RowNum; i++) {
+            std::array<T, ColumnNum> row = a.row(i);
             for (int32_t j = 0; j < ColumnNum; j++) {
-                std::array<std::reference_wrapper<const T>, ColumnNum> row = a.row(i);
-                std::array<std::reference_wrapper<const T>, RowNum> col = b.column(j);
+                std::array<T, RowNum> col = columns[j];
                 T sum = static_cast<T>(0);
                 for (int32_t k = 0; k < RowNum; k++) {
                     sum += row[k] * col[k];
@@ -141,17 +146,17 @@ struct MatrixT {
 
     static VectorT<T, 2> multiply(const MatrixT<T>& a, const VectorT<T, 2>& b)
     {
-        std::array<std::reference_wrapper<const T>, ColumnNum> r1 = a.column(0);
-        std::array<std::reference_wrapper<const T>, ColumnNum> r2 = a.column(1);
+        std::array<T, ColumnNum> r1 = a.column(0);
+        std::array<T, ColumnNum> r2 = a.column(1);
         return VectorT<T, 2>({ (r1.at(0) * b.at(0)) + (r1.at(1) * b.at(1)) + r1.at(2) + r1.at(3),
             (r2.at(0) * b.at(0)) + (r2.at(1) * b.at(1)) + r2.at(2) + r2.at(3) });
     }
 
     static VectorT<T, 3> multiply(const MatrixT<T>& a, const VectorT<T, 3>& b)
     {
-        std::array<std::reference_wrapper<const T>, ColumnNum> r1 = a.column(0);
-        std::array<std::reference_wrapper<const T>, ColumnNum> r2 = a.column(1);
-        std::array<std::reference_wrapper<const T>, ColumnNum> r3 = a.column(2);
+        std::array<T, ColumnNum> r1 = a.column(0);
+        std::array<T, ColumnNum> r2 = a.column(1);
+        std::array<T, ColumnNum> r3 = a.column(2);
         return VectorT<T, 3>({ (r1.at(0) * b.at(0)) + (r1.at(1) * b.at(1)) + (r1.at(2) * b.at(2)) + r1.at(3),
             (r2.at(0) * b.at(0)) + (r2.at(1) * b.at(1)) + (r2.at(2) * b.at(2) + r2.at(3)),
             (r3.at(0) * b.at(0)) + (r3.at(1) * b.at(1)) + (r3.at(2) * b.at(2)) + r3.at(3) });
@@ -159,10 +164,10 @@ struct MatrixT {
 
     static VectorT<T, 4> multiply(const MatrixT<T>& a, const VectorT<T, 4>& b)
     {
-        std::array<std::reference_wrapper<const T>, ColumnNum> r1 = a.column(0);
-        std::array<std::reference_wrapper<const T>, ColumnNum> r2 = a.column(1);
-        std::array<std::reference_wrapper<const T>, ColumnNum> r3 = a.column(2);
-        std::array<std::reference_wrapper<const T>, ColumnNum> r4 = a.column(3);
+        std::array<T, ColumnNum> r1 = a.column(0);
+        std::array<T, ColumnNum> r2 = a.column(1);
+        std::array<T, ColumnNum> r3 = a.column(2);
+        std::array<T, ColumnNum> r4 = a.column(3);
         return VectorT<T, 4>({ (r1.at(0) * b.at(0)) + (r1.at(1) * b.at(1)) + (r1.at(2) * b.at(2)) + (r1.at(3) * b.at(3)),
             (r2.at(0) * b.at(0)) + (r2.at(1) * b.at(1)) + (r2.at(2) * b.at(2)) + (r2.at(3) * b.at(3)),
             (r3.at(0) * b.at(0)) + (r3.at(1) * b.at(1)) + (r3.at(2) * b.at(2)) + (r3.at(3) * b.at(3)),

--- a/src/App/mod/Math/include/Math/Matrix.hpp
+++ b/src/App/mod/Math/include/Math/Matrix.hpp
@@ -33,14 +33,14 @@ struct MatrixT {
 
     // mutable
 
-    std::array<T&, ColumnNum> row(int32_t index)
+    std::array<std::reference_wrapper<T>, ColumnNum> row(int32_t index)
     {
         T& e0 = components[(index * ColumnNum) + 0];
         T& e1 = components[(index * ColumnNum) + 1];
         T& e2 = components[(index * ColumnNum) + 2];
         T& e3 = components[(index * ColumnNum) + 3];
 
-        std::array<T&, 4> a {
+        std::array<std::reference_wrapper<T>, 4> a {
             e0,
             e1,
             e2,
@@ -49,14 +49,14 @@ struct MatrixT {
         return a;
     }
 
-    std::array<T&, RowNum> column(int32_t index)
+    std::array<std::reference_wrapper<T>, RowNum> column(int32_t index)
     {
         T& e0 = components[index];
         T& e1 = components[(1 * ColumnNum) + index + 0];
         T& e2 = components[(2 * ColumnNum) + index + 0];
         T& e3 = components[(3 * ColumnNum) + index + 0];
 
-        std::array<T&, 4> a {
+        std::array<std::reference_wrapper<T>, 4> a {
             e0,
             e1,
             e2,

--- a/src/App/mod/Math/include/Math/Matrix.hpp
+++ b/src/App/mod/Math/include/Math/Matrix.hpp
@@ -125,9 +125,7 @@ struct MatrixT {
     static MatrixT<T> multiply(const MatrixT<T>& a, const MatrixT<T>& b)
     {
         MatrixT<T> m;
-#ifdef _MSC_VER
-#pragma loop(unroll)
-#else
+#ifdef __clang__
 #pragma unroll
 #endif
         for (int32_t i = 0; i < RowNum; i++) {

--- a/src/App/mod/Math/include/Math/Quaternion.hpp
+++ b/src/App/mod/Math/include/Math/Quaternion.hpp
@@ -77,7 +77,7 @@ public:
         return q;
     }
 
-    static QuaternionT<T> multiply(QuaternionT<T> q1, QuaternionT<T> q2)
+    static inline QuaternionT<T> multiply(QuaternionT<T> q1, QuaternionT<T> q2)
     {
         // see: http://marupeke296.com/DXG_No10_Quaternion.html
         VectorT<T, 3> v1 = VectorT<T, 3>({ q1.x, q1.y, q1.z });

--- a/src/App/mod/Math/include/Math/Vector.hpp
+++ b/src/App/mod/Math/include/Math/Vector.hpp
@@ -17,15 +17,16 @@ public:
     }
 
     explicit VectorT(std::array<T, N> src)
-        : components(src)
+        : components()
     {
+        ::memcpy(components, src.data(), sizeof(T) * N);
     }
 
     explicit VectorT(VectorT<T, N - 1> src, T a)
         : components()
     {
-        std::copy(src.components.begin(), src.components.end(), components.begin());
-        std::get<N - 1>(this->components) = a;
+        ::memcpy(components, src.data(), sizeof(T) * (N - 1));
+        this->components[N - 1] = a;
     }
 
     explicit VectorT(T a)
@@ -99,8 +100,8 @@ public:
         {
             T sum = static_cast<T>(0);
             for (int32_t i = 0; i < N; i++) {
-                T av = a.components.at(i);
-                T bv = b.components.at(i);
+                T av = a.components[i];
+                T bv = b.components[i];
                 T diff = av - bv;
                 sum += diff * diff;
             }
@@ -121,50 +122,50 @@ public:
     inline T& x()
     {
         static_assert(N >= 1);
-        return std::get<0>(components);
+        return components[0];
     }
 
     inline T x() const
     {
 
         static_assert(N >= 1);
-        return std::get<0>(components);
+        return components[0];
     }
 
     inline T& y()
     {
         static_assert(N >= 2);
-        return std::get<1>(components);
+        return components[1];
     }
 
     inline T y() const
     {
         static_assert(N >= 2);
-        return std::get<1>(components);
+        return components[1];
     }
 
     inline T& z()
     {
         static_assert(N >= 3);
-        return std::get<2>(components);
+        return components[2];
     }
 
     inline T z() const
     {
         static_assert(N >= 3);
-        return std::get<2>(components);
+        return components[2];
     }
 
     inline T& w()
     {
         static_assert(N >= 4);
-        return std::get<3>(components);
+        return components[3];
     }
 
     inline T w() const
     {
         static_assert(N >= 4);
-        return std::get<3>(components);
+        return components[3];
     }
 
     inline T& r()
@@ -222,7 +223,7 @@ public:
         std::stringstream ss;
         ss << '(';
         for (int32_t i = 0; i < N; i++) {
-            ss << components.at(i);
+            ss << components[i];
             if (i != N - 1) {
                 ss << ',';
             }
@@ -233,12 +234,12 @@ public:
 
     T* data()
     {
-        return this->components.data();
+        return this->components;
     }
 
     const T* data() const
     {
-        return this->components.data();
+        return this->components;
     }
 
     void reset(T a)
@@ -399,7 +400,7 @@ public:
         return os;
     }
 
-    std::array<T, N> components;
+    T components[N];
 };
 
 template <typename T, int32_t N>

--- a/src/App/mod/Math/include/Math/Vector.hpp
+++ b/src/App/mod/Math/include/Math/Vector.hpp
@@ -44,7 +44,8 @@ public:
         {
             Type sum = static_cast<Type>(0);
             for (int32_t i = 0; i < N; i++) {
-                sum += (a[i] * b[i]);
+                // sum += (a[i] * b[i]);
+                sum = std::fmaf(a[i], b[i], sum);
             }
             return sum;
         }
@@ -283,6 +284,11 @@ public:
     explicit operator VectorT<int32_t, N>() const
     {
         VectorT<int32_t, N> v;
+#ifdef _MSC_VER
+#pragma loop(unroll)
+#else
+#pragma unroll
+#endif
         for (int32_t i = 0; i < N; i++) {
             v.components[i] = static_cast<int32_t>(components[i]);
         }
@@ -292,6 +298,11 @@ public:
     explicit operator VectorT<float, N>() const
     {
         VectorT<float, N> v;
+#ifdef _MSC_VER
+#pragma loop(unroll)
+#else
+#pragma unroll
+#endif
         for (int32_t i = 0; i < N; i++) {
             v.components[i] = static_cast<float>(components[i]);
         }
@@ -305,57 +316,92 @@ public:
         return VectorT<T, N - 1>(a);
     }
 
-    VectorT<T, N>& operator+=(const VectorT<T, N>& a)
+    inline VectorT<T, N>& operator+=(const VectorT<T, N>& a)
     {
+#ifdef _MSC_VER
+#pragma loop(unroll)
+#else
+#pragma unroll
+#endif
         for (int32_t i = 0; i < N; i++) {
             components[i] = components[i] + a[i];
         }
         return *this;
     }
 
-    VectorT<T, N>& operator-=(const VectorT<T, N>& a)
+    inline VectorT<T, N>& operator-=(const VectorT<T, N>& a)
     {
+#ifdef _MSC_VER
+#pragma loop(unroll)
+#else
+#pragma unroll
+#endif
         for (int32_t i = 0; i < N; i++) {
             components[i] = components[i] - a[i];
         }
         return *this;
     }
 
-    VectorT<T, N>& operator*=(const VectorT<T, N>& a)
+    inline VectorT<T, N>& operator*=(const VectorT<T, N>& a)
     {
+#ifdef _MSC_VER
+#pragma loop(unroll)
+#else
+#pragma unroll
+#endif
         for (int32_t i = 0; i < N; i++) {
             components[i] = components[i] * a[i];
         }
         return *this;
     }
 
-    VectorT<T, N>& operator/=(const VectorT<T, N>& a)
+    inline VectorT<T, N>& operator/=(const VectorT<T, N>& a)
     {
+#ifdef _MSC_VER
+#pragma loop(unroll)
+#else
+#pragma unroll
+#endif
         for (int32_t i = 0; i < N; i++) {
             components[i] = components[i] / a[i];
         }
         return *this;
     }
 
-    VectorT<T, N>& operator*=(const T scale)
+    inline VectorT<T, N>& operator*=(const T scale)
     {
+#ifdef _MSC_VER
+#pragma loop(unroll)
+#else
+#pragma unroll
+#endif
         for (int32_t i = 0; i < N; i++) {
             components[i] = components[i] * scale;
         }
         return *this;
     }
 
-    VectorT<T, N>& operator/=(const T scale)
+    inline VectorT<T, N>& operator/=(const T scale)
     {
+#ifdef _MSC_VER
+#pragma loop(unroll)
+#else
+#pragma unroll
+#endif
         for (int32_t i = 0; i < N; i++) {
             components[i] = components[i] / scale;
         }
         return *this;
     }
 
-    VectorT<T, N> operator-() const
+    inline VectorT<T, N> operator-() const
     {
         VectorT<T, N> v;
+#ifdef _MSC_VER
+#pragma loop(unroll)
+#else
+#pragma unroll
+#endif
         for (int32_t i = 0; i < N; i++) {
             v.components[i] = -components[i];
         }
@@ -372,9 +418,14 @@ public:
 };
 
 template <typename T, int32_t N>
-VectorT<T, N> operator+(const VectorT<T, N>& a, const VectorT<T, N>& b)
+inline VectorT<T, N> operator+(const VectorT<T, N>& a, const VectorT<T, N>& b)
 {
     VectorT<T, N> ret;
+#ifdef _MSC_VER
+#pragma loop(unroll)
+#else
+#pragma unroll
+#endif
     for (int32_t i = 0; i < N; i++) {
         ret[i] = a[i] + b[i];
     }
@@ -382,9 +433,14 @@ VectorT<T, N> operator+(const VectorT<T, N>& a, const VectorT<T, N>& b)
 }
 
 template <typename T, int32_t N>
-VectorT<T, N> operator-(const VectorT<T, N>& a, const VectorT<T, N>& b)
+inline VectorT<T, N> operator-(const VectorT<T, N>& a, const VectorT<T, N>& b)
 {
     VectorT<T, N> ret;
+#ifdef _MSC_VER
+#pragma loop(unroll)
+#else
+#pragma unroll
+#endif
     for (int32_t i = 0; i < N; i++) {
         ret[i] = a[i] - b[i];
     }
@@ -392,9 +448,14 @@ VectorT<T, N> operator-(const VectorT<T, N>& a, const VectorT<T, N>& b)
 }
 
 template <typename T, int32_t N>
-VectorT<T, N> operator*(const VectorT<T, N>& a, const VectorT<T, N>& b)
+inline VectorT<T, N> operator*(const VectorT<T, N>& a, const VectorT<T, N>& b)
 {
     VectorT<T, N> ret;
+#ifdef _MSC_VER
+#pragma loop(unroll)
+#else
+#pragma unroll
+#endif
     for (int32_t i = 0; i < N; i++) {
         ret[i] = a[i] * b[i];
     }
@@ -402,9 +463,14 @@ VectorT<T, N> operator*(const VectorT<T, N>& a, const VectorT<T, N>& b)
 }
 
 template <typename T, int32_t N>
-VectorT<T, N> operator/(const VectorT<T, N>& a, const VectorT<T, N>& b)
+inline VectorT<T, N> operator/(const VectorT<T, N>& a, const VectorT<T, N>& b)
 {
     VectorT<T, N> ret;
+#ifdef _MSC_VER
+#pragma loop(unroll)
+#else
+#pragma unroll
+#endif
     for (int32_t i = 0; i < N; i++) {
         ret[i] = a[i] / b[i];
     }
@@ -412,9 +478,14 @@ VectorT<T, N> operator/(const VectorT<T, N>& a, const VectorT<T, N>& b)
 }
 
 template <typename T, int32_t N>
-VectorT<T, N> operator*(const VectorT<T, N>& a, T scale)
+inline VectorT<T, N> operator*(const VectorT<T, N>& a, T scale)
 {
     VectorT<T, N> ret;
+#ifdef _MSC_VER
+#pragma loop(unroll)
+#else
+#pragma unroll
+#endif
     for (int32_t i = 0; i < N; i++) {
         ret[i] = a[i] * scale;
     }
@@ -422,9 +493,14 @@ VectorT<T, N> operator*(const VectorT<T, N>& a, T scale)
 }
 
 template <typename T, int32_t N>
-VectorT<T, N> operator/(const VectorT<T, N>& a, T scale)
+inline VectorT<T, N> operator/(const VectorT<T, N>& a, T scale)
 {
     VectorT<T, N> ret;
+#ifdef _MSC_VER
+#pragma loop(unroll)
+#else
+#pragma unroll
+#endif
     for (int32_t i = 0; i < N; i++) {
         ret[i] = a[i] / scale;
     }
@@ -432,8 +508,13 @@ VectorT<T, N> operator/(const VectorT<T, N>& a, T scale)
 }
 
 template <typename T, int32_t N>
-bool operator==(const VectorT<T, N>& a, const VectorT<T, N>& b)
+inline bool operator==(const VectorT<T, N>& a, const VectorT<T, N>& b)
 {
+#ifdef _MSC_VER
+#pragma loop(unroll)
+#else
+#pragma unroll
+#endif
     for (int32_t i = 0; i < N; i++) {
         if (!Mathf::equals(a.components[i], b.components[i])) {
             return false;
@@ -443,7 +524,7 @@ bool operator==(const VectorT<T, N>& a, const VectorT<T, N>& b)
 }
 
 template <typename T, int32_t N>
-bool operator!=(const VectorT<T, N>& a, const VectorT<T, N>& b)
+inline bool operator!=(const VectorT<T, N>& a, const VectorT<T, N>& b)
 {
     return !(a == b);
 }

--- a/src/App/mod/Math/include/Math/Vector.hpp
+++ b/src/App/mod/Math/include/Math/Vector.hpp
@@ -412,6 +412,7 @@ public:
         return os;
     }
 
+    // NOTE: _ITERATOR_DEBUG_LEVELや_CONTAINER_DEBUG_LEVELの影響を受けるstd::arrayは使わない
     T components[N];
 };
 

--- a/src/App/mod/Math/include/Math/Vector.hpp
+++ b/src/App/mod/Math/include/Math/Vector.hpp
@@ -40,7 +40,7 @@ public:
     struct DotHelper {
         using Type = T;
 
-        static Type compute(const VectorT<T, NumV>& a, const VectorT<T, NumV>& b)
+        static inline Type compute(const VectorT<T, NumV>& a, const VectorT<T, NumV>& b)
         {
             Type sum = static_cast<Type>(0);
             for (int32_t i = 0; i < N; i++) {
@@ -67,7 +67,7 @@ public:
         static inline constexpr int32_t NumV = 2;
         using Type = T;
 
-        static Type compute(const VectorT<T, NumV>& a, const VectorT<T, NumV>& b)
+        static inline Type compute(const VectorT<T, NumV>& a, const VectorT<T, NumV>& b)
         {
             return a.x() * b.y() - a.y() * b.x();
         }
@@ -78,7 +78,7 @@ public:
         static inline constexpr int32_t NumV = 3;
         using Type = VectorT<T, NumV>;
 
-        static Type compute(const VectorT<T, NumV>& a, const VectorT<T, NumV>& b)
+        static inline Type compute(const VectorT<T, NumV>& a, const VectorT<T, NumV>& b)
         {
             return Type(std::array<T, NumV> {
                 a.y() * b.z() - b.y() * a.z(),

--- a/src/App/mod/Math/include/Math/Vector.hpp
+++ b/src/App/mod/Math/include/Math/Vector.hpp
@@ -118,50 +118,50 @@ public:
     inline T& x()
     {
         static_assert(N >= 1);
-        return components.at(0);
+        return std::get<0>(components);
     }
 
     inline T x() const
     {
 
         static_assert(N >= 1);
-        return components.at(0);
+        return std::get<0>(components);
     }
 
     inline T& y()
     {
         static_assert(N >= 2);
-        return components.at(1);
+        return std::get<1>(components);
     }
 
     inline T y() const
     {
         static_assert(N >= 2);
-        return components.at(1);
+        return std::get<1>(components);
     }
 
     inline T& z()
     {
         static_assert(N >= 3);
-        return components.at(2);
+        return std::get<2>(components);
     }
 
     inline T z() const
     {
         static_assert(N >= 3);
-        return components.at(2);
+        return std::get<2>(components);
     }
 
     inline T& w()
     {
         static_assert(N >= 4);
-        return components.at(3);
+        return std::get<3>(components);
     }
 
     inline T w() const
     {
         static_assert(N >= 4);
-        return components.at(3);
+        return std::get<3>(components);
     }
 
     inline T& r()

--- a/src/App/mod/Math/include/Math/Vector.hpp
+++ b/src/App/mod/Math/include/Math/Vector.hpp
@@ -107,12 +107,12 @@ public:
 
     inline T& at(int32_t index)
     {
-        return components.at(index);
+        return components[index];
     }
 
     inline T at(int32_t index) const
     {
-        return components.at(index);
+        return components[index];
     }
 
     inline T& x()

--- a/src/App/mod/Math/include/Math/Vector.hpp
+++ b/src/App/mod/Math/include/Math/Vector.hpp
@@ -234,8 +234,8 @@ public:
 #pragma unroll
 #endif
         for (int32_t i = 0; i < N; i++) {
-            // p += static_cast<T>(components[i] * components[i]);
-            p = std::fmaf(components[i], components[i], p);
+            p += static_cast<T>(components[i] * components[i]);
+            // p = std::fmaf(components[i], components[i], p);
         }
         return static_cast<T>(std::sqrt(p));
     }
@@ -254,7 +254,7 @@ public:
         return v;
     }
 
-    static inline typename T dot(const VectorT<T, N>& a, const VectorT<T, N>& b)
+    static inline T dot(const VectorT<T, N>& a, const VectorT<T, N>& b)
     {
         T sum = static_cast<T>(0);
 #ifdef __clang__

--- a/src/App/mod/Math/include/Math/Vector.hpp
+++ b/src/App/mod/Math/include/Math/Vector.hpp
@@ -35,26 +35,6 @@ public:
         reset(a);
     }
 
-    // DotHelper
-
-    template <int32_t NumV>
-    struct DotHelper {
-        using Type = T;
-
-        static inline Type compute(const VectorT<T, NumV>& a, const VectorT<T, NumV>& b)
-        {
-            Type sum = static_cast<Type>(0);
-#ifdef __clang__
-#pragma unroll
-#endif
-            for (int32_t i = 0; i < N; i++) {
-                // sum += (a[i] * b[i]);
-                sum = std::fmaf(a[i], b[i], sum);
-            }
-            return sum;
-        }
-    };
-
     // CrossHelper
 
     template <int32_t NumV>
@@ -274,7 +254,7 @@ public:
         return v;
     }
 
-    static inline typename DotHelper<N>::Type dot(const VectorT<T, N>& a, const VectorT<T, N>& b)
+    static inline typename T dot(const VectorT<T, N>& a, const VectorT<T, N>& b)
     {
         T sum = static_cast<T>(0);
 #ifdef __clang__

--- a/src/App/mod/Math/include/Math/Vector.hpp
+++ b/src/App/mod/Math/include/Math/Vector.hpp
@@ -43,9 +43,7 @@ public:
         static inline Type compute(const VectorT<T, NumV>& a, const VectorT<T, NumV>& b)
         {
             Type sum = static_cast<Type>(0);
-#ifdef _MSC_VER
-#pragma loop(unroll)
-#else
+#ifdef __clang__
 #pragma unroll
 #endif
             for (int32_t i = 0; i < N; i++) {
@@ -289,9 +287,7 @@ public:
     explicit operator VectorT<int32_t, N>() const
     {
         VectorT<int32_t, N> v;
-#ifdef _MSC_VER
-#pragma loop(unroll)
-#else
+#ifdef __clang__
 #pragma unroll
 #endif
         for (int32_t i = 0; i < N; i++) {
@@ -303,9 +299,7 @@ public:
     explicit operator VectorT<float, N>() const
     {
         VectorT<float, N> v;
-#ifdef _MSC_VER
-#pragma loop(unroll)
-#else
+#ifdef __clang__
 #pragma unroll
 #endif
         for (int32_t i = 0; i < N; i++) {
@@ -323,9 +317,7 @@ public:
 
     inline VectorT<T, N>& operator+=(const VectorT<T, N>& a)
     {
-#ifdef _MSC_VER
-#pragma loop(unroll)
-#else
+#ifdef __clang__
 #pragma unroll
 #endif
         for (int32_t i = 0; i < N; i++) {
@@ -336,9 +328,7 @@ public:
 
     inline VectorT<T, N>& operator-=(const VectorT<T, N>& a)
     {
-#ifdef _MSC_VER
-#pragma loop(unroll)
-#else
+#ifdef __clang__
 #pragma unroll
 #endif
         for (int32_t i = 0; i < N; i++) {
@@ -349,9 +339,7 @@ public:
 
     inline VectorT<T, N>& operator*=(const VectorT<T, N>& a)
     {
-#ifdef _MSC_VER
-#pragma loop(unroll)
-#else
+#ifdef __clang__
 #pragma unroll
 #endif
         for (int32_t i = 0; i < N; i++) {
@@ -362,9 +350,7 @@ public:
 
     inline VectorT<T, N>& operator/=(const VectorT<T, N>& a)
     {
-#ifdef _MSC_VER
-#pragma loop(unroll)
-#else
+#ifdef __clang__
 #pragma unroll
 #endif
         for (int32_t i = 0; i < N; i++) {
@@ -375,9 +361,7 @@ public:
 
     inline VectorT<T, N>& operator*=(const T scale)
     {
-#ifdef _MSC_VER
-#pragma loop(unroll)
-#else
+#ifdef __clang__
 #pragma unroll
 #endif
         for (int32_t i = 0; i < N; i++) {
@@ -388,9 +372,7 @@ public:
 
     inline VectorT<T, N>& operator/=(const T scale)
     {
-#ifdef _MSC_VER
-#pragma loop(unroll)
-#else
+#ifdef __clang__
 #pragma unroll
 #endif
         for (int32_t i = 0; i < N; i++) {
@@ -402,9 +384,7 @@ public:
     inline VectorT<T, N> operator-() const
     {
         VectorT<T, N> v;
-#ifdef _MSC_VER
-#pragma loop(unroll)
-#else
+#ifdef __clang__
 #pragma unroll
 #endif
         for (int32_t i = 0; i < N; i++) {
@@ -426,9 +406,7 @@ template <typename T, int32_t N>
 inline VectorT<T, N> operator+(const VectorT<T, N>& a, const VectorT<T, N>& b)
 {
     VectorT<T, N> ret;
-#ifdef _MSC_VER
-#pragma loop(unroll)
-#else
+#ifdef __clang__
 #pragma unroll
 #endif
     for (int32_t i = 0; i < N; i++) {
@@ -441,9 +419,7 @@ template <typename T, int32_t N>
 inline VectorT<T, N> operator-(const VectorT<T, N>& a, const VectorT<T, N>& b)
 {
     VectorT<T, N> ret;
-#ifdef _MSC_VER
-#pragma loop(unroll)
-#else
+#ifdef __clang__
 #pragma unroll
 #endif
     for (int32_t i = 0; i < N; i++) {
@@ -456,9 +432,7 @@ template <typename T, int32_t N>
 inline VectorT<T, N> operator*(const VectorT<T, N>& a, const VectorT<T, N>& b)
 {
     VectorT<T, N> ret;
-#ifdef _MSC_VER
-#pragma loop(unroll)
-#else
+#ifdef __clang__
 #pragma unroll
 #endif
     for (int32_t i = 0; i < N; i++) {
@@ -471,9 +445,7 @@ template <typename T, int32_t N>
 inline VectorT<T, N> operator/(const VectorT<T, N>& a, const VectorT<T, N>& b)
 {
     VectorT<T, N> ret;
-#ifdef _MSC_VER
-#pragma loop(unroll)
-#else
+#ifdef __clang__
 #pragma unroll
 #endif
     for (int32_t i = 0; i < N; i++) {
@@ -486,9 +458,7 @@ template <typename T, int32_t N>
 inline VectorT<T, N> operator*(const VectorT<T, N>& a, T scale)
 {
     VectorT<T, N> ret;
-#ifdef _MSC_VER
-#pragma loop(unroll)
-#else
+#ifdef __clang__
 #pragma unroll
 #endif
     for (int32_t i = 0; i < N; i++) {
@@ -501,9 +471,7 @@ template <typename T, int32_t N>
 inline VectorT<T, N> operator/(const VectorT<T, N>& a, T scale)
 {
     VectorT<T, N> ret;
-#ifdef _MSC_VER
-#pragma loop(unroll)
-#else
+#ifdef __clang__
 #pragma unroll
 #endif
     for (int32_t i = 0; i < N; i++) {
@@ -515,9 +483,7 @@ inline VectorT<T, N> operator/(const VectorT<T, N>& a, T scale)
 template <typename T, int32_t N>
 inline bool operator==(const VectorT<T, N>& a, const VectorT<T, N>& b)
 {
-#ifdef _MSC_VER
-#pragma loop(unroll)
-#else
+#ifdef __clang__
 #pragma unroll
 #endif
     for (int32_t i = 0; i < N; i++) {

--- a/src/App/mod/Math/include/Math/Vector.hpp
+++ b/src/App/mod/Math/include/Math/Vector.hpp
@@ -250,8 +250,12 @@ public:
     inline T length() const
     {
         T p = static_cast<T>(0);
+#ifdef __clang__
+#pragma unroll
+#endif
         for (int32_t i = 0; i < N; i++) {
-            p += static_cast<T>(std::pow(components[i], 2));
+            // p += static_cast<T>(components[i] * components[i]);
+            p = std::fmaf(components[i], components[i], p);
         }
         return static_cast<T>(std::sqrt(p));
     }
@@ -272,7 +276,15 @@ public:
 
     static inline typename DotHelper<N>::Type dot(const VectorT<T, N>& a, const VectorT<T, N>& b)
     {
-        return DotHelper<N>::compute(a, b);
+        T sum = static_cast<T>(0);
+#ifdef __clang__
+#pragma unroll
+#endif
+        for (int32_t i = 0; i < N; i++) {
+            sum += (a[i] * b[i]);
+            // sum = std::fmaf(a.components[i], b.components[i], sum);
+        }
+        return sum;
     }
 
     static inline typename CrossHelper<N>::Type cross(const VectorT<T, N>& a, const VectorT<T, N>& b)

--- a/src/App/mod/Math/include/Math/Vector.hpp
+++ b/src/App/mod/Math/include/Math/Vector.hpp
@@ -43,6 +43,11 @@ public:
         static inline Type compute(const VectorT<T, NumV>& a, const VectorT<T, NumV>& b)
         {
             Type sum = static_cast<Type>(0);
+#ifdef _MSC_VER
+#pragma loop(unroll)
+#else
+#pragma unroll
+#endif
             for (int32_t i = 0; i < N; i++) {
                 // sum += (a[i] * b[i]);
                 sum = std::fmaf(a[i], b[i], sum);

--- a/src/App/mod/Math/include/Math/Vector.hpp
+++ b/src/App/mod/Math/include/Math/Vector.hpp
@@ -235,7 +235,7 @@ public:
 #endif
         for (int32_t i = 0; i < N; i++) {
             p += static_cast<T>(components[i] * components[i]);
-            // p = std::fmaf(components[i], components[i], p);
+            // p = Mathf::fma(components[i], components[i], p);
         }
         return static_cast<T>(std::sqrt(p));
     }
@@ -262,7 +262,7 @@ public:
 #endif
         for (int32_t i = 0; i < N; i++) {
             sum += (a[i] * b[i]);
-            // sum = std::fmaf(a.components[i], b.components[i], sum);
+            // sum = Mathf::fma(a.components[i], b.components[i], sum);
         }
         return sum;
     }

--- a/src/App/mod/Math/test/CMakeLists.txt
+++ b/src/App/mod/Math/test/CMakeLists.txt
@@ -3,7 +3,7 @@ project(Lib-Math-Test CXX)
 
 add_executable(Lib-Math-Test main.cpp)
 target_compile_options(Lib-Math-Test PRIVATE $<$<BOOL:${MSVC}>: /utf-8>)
-target_compile_features(Lib-Math-Test PRIVATE cxx_std_17)
+target_compile_features(Lib-Math-Test PRIVATE cxx_std_20)
 target_include_directories(
     Lib-Math-Test
     PRIVATE

--- a/src/App/mod/Utils/CMakeLists.txt
+++ b/src/App/mod/Utils/CMakeLists.txt
@@ -14,11 +14,13 @@ set(SOURCES
     ./include/Utils/Time.hpp
     ./include/Utils/Stopwatch.hpp
     ./include/Utils/Random.hpp
+    ./include/Utils/Clock.hpp
     ./lib/Utils/String.cpp
     ./lib/Utils/IO.cpp
     ./lib/Utils/Time.cpp
     ./lib/Utils/Stopwatch.cpp
     ./lib/Utils/Random.cpp
+    ./lib/Utils/Clock.cpp
 )
 source_group(
     TREE

--- a/src/App/mod/Utils/include/Utils.hpp
+++ b/src/App/mod/Utils/include/Utils.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <Utils/BlockingQueue.hpp>
 #include <Utils/IO.hpp>
 #include <Utils/Random.hpp>
 #include <Utils/Stopwatch.hpp>

--- a/src/App/mod/Utils/include/Utils.hpp
+++ b/src/App/mod/Utils/include/Utils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <Utils/BlockingQueue.hpp>
+#include <Utils/Clock.hpp>
 #include <Utils/IO.hpp>
 #include <Utils/Random.hpp>
 #include <Utils/Stopwatch.hpp>

--- a/src/App/mod/Utils/include/Utils.hpp
+++ b/src/App/mod/Utils/include/Utils.hpp
@@ -1,7 +1,7 @@
 #pragma once
-#include <Utils/BlockingQueue.hpp>
 #include <Utils/Clock.hpp>
 #include <Utils/IO.hpp>
+#include <Utils/LockfreeQueue.hpp>
 #include <Utils/Random.hpp>
 #include <Utils/Stopwatch.hpp>
 #include <Utils/String.hpp>

--- a/src/App/mod/Utils/include/Utils/BlockingQueue.hpp
+++ b/src/App/mod/Utils/include/Utils/BlockingQueue.hpp
@@ -25,7 +25,7 @@ public:
         }
     }
 
-    void dequeue()
+    T dequeue()
     {
         while (true) {
             std::lock_guard<std::mutex> guard(m_mutex);

--- a/src/App/mod/Utils/include/Utils/BlockingQueue.hpp
+++ b/src/App/mod/Utils/include/Utils/BlockingQueue.hpp
@@ -28,7 +28,7 @@ public:
     T dequeue()
     {
         while (true) {
-            std::lock_guard<std::mutex> guard(m_mutex);
+            std::unique_lock<std::mutex> guard(m_mutex);
             if (m_queue.empty()) {
                 m_condVar.wait(guard);
             }

--- a/src/App/mod/Utils/include/Utils/BlockingQueue.hpp
+++ b/src/App/mod/Utils/include/Utils/BlockingQueue.hpp
@@ -1,0 +1,55 @@
+#pragma once
+#include <mutex>
+#include <queue>
+#include <thread>
+// see: https://qiita.com/kumagi/items/4224282d95804d46fc39
+
+namespace Lib::Utils {
+template <typename T>
+class BlockingQueue {
+public:
+    explicit BlockingQueue()
+        : m_mutex()
+        , m_condVar()
+        , m_queue()
+    {
+    }
+
+    void enqueue(const T& item)
+    {
+        std::lock_guard<std::mutex> guard(m_mutex);
+        bool wasEmpty = m_queue.empty();
+        m_queue.push(item);
+        if (wasEmpty) {
+            m_condVar.notify_all();
+        }
+    }
+
+    void dequeue()
+    {
+        while (true) {
+            std::lock_guard<std::mutex> guard(m_mutex);
+            if (m_queue.empty()) {
+                m_condVar.wait(guard);
+            }
+            if (m_queue.empty()) {
+                continue;
+            }
+            T result = m_queue.front();
+            m_queue.pop();
+            return result;
+        }
+    }
+
+    size_t size() const
+    {
+        std::lock_guard<std::mutex>(m_mutex);
+        return m_queue.size();
+    }
+
+private:
+    mutable std::mutex m_mutex;
+    mutable std::condition_variable m_condVar;
+    std::queue<T> m_queue;
+};
+}

--- a/src/App/mod/Utils/include/Utils/Clock.hpp
+++ b/src/App/mod/Utils/include/Utils/Clock.hpp
@@ -1,0 +1,27 @@
+#pragma once
+// chronoヘッダーは使えないので、代わりの時計クラス
+// c++20からchronoはformatに依存しているのだが、
+// chronoとopenmpは同居できないらしい
+// しかしdirectxtexを使う都合openmpは必要
+// という事情がありchronoは使えない…
+#include <Windows.h>
+#include <cstdint>
+
+namespace Lib::Utils {
+class Clock {
+public:
+    static float counter();
+
+#if SOLID_ENABLE_INTERNAL
+    static void initialize();
+    static void destroy();
+#endif
+
+private:
+    static LARGE_INTEGER s_freq;
+    static LARGE_INTEGER s_counter;
+    static int64_t s_start;
+    static double s_pcFreq;
+    Clock();
+};
+}

--- a/src/App/mod/Utils/include/Utils/LockfreeQueue.hpp
+++ b/src/App/mod/Utils/include/Utils/LockfreeQueue.hpp
@@ -9,40 +9,40 @@ template <typename T>
 class LockfreeQueue {
 public:
     explicit LockfreeQueue(size_t capacity)
-        : buffer_(capacity)
-        , head_(0)
-        , tail_(0)
+        : m_buffer(capacity)
+        , m_head(0)
+        , m_tail(0)
     {
     }
 
     bool enqueue(const T& item)
     {
-        size_t currentTail = tail_.load(std::memory_order_relaxed);
-        size_t nextTail = (currentTail + 1) % buffer_.size();
-        if (nextTail == head_.load(std::memory_order_acquire)) {
+        size_t currentTail = m_tail.load(std::memory_order_relaxed);
+        size_t nextTail = (currentTail + 1) % m_buffer.size();
+        if (nextTail == m_head.load(std::memory_order_acquire)) {
             // キューが満杯
             return false;
         }
-        buffer_[currentTail] = item;
-        tail_.store(nextTail, std::memory_order_release);
+        m_buffer[currentTail] = item;
+        m_tail.store(nextTail, std::memory_order_release);
         return true;
     }
 
     bool dequeue(T& item)
     {
-        size_t currentHead = head_.load(std::memory_order_relaxed);
-        if (currentHead == tail_.load(std::memory_order_acquire)) {
+        size_t currentHead = m_head.load(std::memory_order_relaxed);
+        if (currentHead == m_tail.load(std::memory_order_acquire)) {
             // キューが空
             return false;
         }
-        item = buffer_[currentHead];
-        head_.store((currentHead + 1) % buffer_.size(), std::memory_order_release);
+        item = m_buffer[currentHead];
+        m_head.store((currentHead + 1) % m_buffer.size(), std::memory_order_release);
         return true;
     }
 
 private:
-    std::vector<T> buffer_;
-    std::atomic<size_t> head_;
-    std::atomic<size_t> tail_;
+    std::vector<T> m_buffer;
+    std::atomic<size_t> m_head;
+    std::atomic<size_t> m_tail;
 };
 }

--- a/src/App/mod/Utils/include/Utils/LockfreeQueue.hpp
+++ b/src/App/mod/Utils/include/Utils/LockfreeQueue.hpp
@@ -6,9 +6,9 @@
 
 namespace Lib::Utils {
 template <typename T>
-class BlockingQueue {
+class LockfreeQueue {
 public:
-    explicit BlockingQueue(size_t capacity)
+    explicit LockfreeQueue(size_t capacity)
         : buffer_(capacity)
         , head_(0)
         , tail_(0)

--- a/src/App/mod/Utils/include/Utils/Stopwatch.hpp
+++ b/src/App/mod/Utils/include/Utils/Stopwatch.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <chrono>
 #include <iostream>
 #include <string>
 
@@ -13,7 +12,7 @@ public:
     void dump(const std::string& label, std::ostream& os);
 
 private:
-    std::chrono::system_clock::time_point m_start;
-    std::chrono::system_clock::time_point m_end;
+    float m_start;
+    float m_end;
 };
 }

--- a/src/App/mod/Utils/include/Utils/Time.hpp
+++ b/src/App/mod/Utils/include/Utils/Time.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <chrono>
 
 namespace Lib::Utils {
 class Time {
@@ -14,8 +13,8 @@ public:
 
 private:
     Time() = delete;
-    static std::chrono::system_clock::time_point s_start;
-    static std::chrono::system_clock::time_point s_end;
-    static std::chrono::milliseconds s_overSleep;
+    static float s_start;
+    static float s_end;
+    static float s_overSleep;
 };
 }

--- a/src/App/mod/Utils/lib/Utils/Clock.cpp
+++ b/src/App/mod/Utils/lib/Utils/Clock.cpp
@@ -1,0 +1,24 @@
+#include <Utils/Clock.hpp>
+
+namespace Lib::Utils {
+LARGE_INTEGER Clock::s_freq;
+LARGE_INTEGER Clock::s_counter;
+int64_t Clock::s_start;
+double Clock::s_pcFreq;
+
+float Clock::counter()
+{
+    QueryPerformanceCounter(&s_counter);
+    return (float)(double(s_counter.QuadPart - s_start) / s_pcFreq);
+}
+
+void Clock::initialize()
+{
+    QueryPerformanceFrequency(&s_freq);
+    s_pcFreq = s_freq.QuadPart;
+
+    QueryPerformanceCounter(&s_counter);
+    s_start = s_counter.QuadPart;
+}
+void Clock::destroy() { }
+}

--- a/src/App/mod/Utils/lib/Utils/Stopwatch.cpp
+++ b/src/App/mod/Utils/lib/Utils/Stopwatch.cpp
@@ -1,3 +1,4 @@
+#include <Utils/Clock.hpp>
 #include <Utils/Stopwatch.hpp>
 
 namespace Lib::Utils {
@@ -8,17 +9,17 @@ Stopwatch::Stopwatch()
 
 void Stopwatch::start()
 {
-    m_start = std::chrono::system_clock::now();
+    m_start = Clock::counter();
 }
 
 void Stopwatch::stop()
 {
-    m_end = std::chrono::system_clock::now();
+    m_end = Clock::counter();
 }
 
 void Stopwatch::dump(const std::string& label, std::ostream& os)
 {
-    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(m_end - m_start);
-    os << label << ":" << duration.count() << "msec." << std::endl;
+    float duration = (m_end - m_start) * 1000.0f;
+    os << label << ":" << duration << "msec." << std::endl;
 }
 }

--- a/src/App/mod/Utils/lib/Utils/Time.cpp
+++ b/src/App/mod/Utils/lib/Utils/Time.cpp
@@ -1,5 +1,6 @@
 #include <Utils/Clock.hpp>
 #include <Utils/Time.hpp>
+#include <Windows.h>
 #include <thread>
 
 namespace Lib::Utils {
@@ -22,12 +23,11 @@ void Time::end()
 }
 void Time::sync()
 {
-    float frameDuration = (1000.0f / 60.0f);
+    float frameDuration = (1.0f / 60.0f);
     float elapsedTime = s_end - s_start;
     float sleepTime = frameDuration - elapsedTime - s_overSleep;
     if (sleepTime > 0) {
-        // NOTE: DirectXがリフレッシュレートに合わせて同期するので不要
-        // std::this_thread::sleep_for(sleepTime);
+        ::Sleep((DWORD)(sleepTime * 1000.0f));
         s_overSleep = (Clock::counter() - s_end) - sleepTime;
     } else {
         s_overSleep = 0;

--- a/src/App/mod/Utils/lib/Utils/Time.cpp
+++ b/src/App/mod/Utils/lib/Utils/Time.cpp
@@ -1,20 +1,20 @@
+#include <Utils/Clock.hpp>
 #include <Utils/Time.hpp>
 #include <thread>
 
 namespace Lib::Utils {
-std::chrono::system_clock::time_point Time::s_start;
-std::chrono::system_clock::time_point Time::s_end;
-std::chrono::milliseconds Time::s_overSleep;
+float Time::s_start;
+float Time::s_end;
+float Time::s_overSleep;
 float Time::s_deltaTime;
 // public
 
-void Time::begin() { s_start = std::chrono::system_clock::now(); }
+void Time::begin() { s_start = Clock::counter(); }
 void Time::end()
 {
-    s_end = std::chrono::system_clock::now();
+    s_end = Clock::counter();
 
-    auto elapsedTime = std::chrono::duration<float>(s_end - s_start);
-    s_deltaTime = elapsedTime.count();
+    s_deltaTime = (s_end - s_start);
 
     if (s_deltaTime > 1.0f) {
         s_deltaTime = 1.0f;
@@ -22,15 +22,15 @@ void Time::end()
 }
 void Time::sync()
 {
-    std::chrono::milliseconds frameDuration(1000 / 60);
-    auto elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(s_end - s_start);
-    auto sleepTime = frameDuration - elapsedTime - s_overSleep;
-    if (sleepTime.count() > 0) {
+    float frameDuration = (1000.0f / 60.0f);
+    float elapsedTime = s_end - s_start;
+    float sleepTime = frameDuration - elapsedTime - s_overSleep;
+    if (sleepTime > 0) {
         // NOTE: DirectXがリフレッシュレートに合わせて同期するので不要
         // std::this_thread::sleep_for(sleepTime);
-        s_overSleep = std::chrono::duration_cast<std::chrono::milliseconds>((std::chrono::system_clock::now() - s_end) - sleepTime);
+        s_overSleep = (Clock::counter() - s_end) - sleepTime;
     } else {
-        s_overSleep = std::chrono::milliseconds(0);
+        s_overSleep = 0;
     }
 }
 

--- a/src/App/mod/Utils/lib/Utils/Time.cpp
+++ b/src/App/mod/Utils/lib/Utils/Time.cpp
@@ -26,7 +26,8 @@ void Time::sync()
     auto elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(s_end - s_start);
     auto sleepTime = frameDuration - elapsedTime - s_overSleep;
     if (sleepTime.count() > 0) {
-        std::this_thread::sleep_for(sleepTime);
+        // NOTE: DirectXがリフレッシュレートに合わせて同期するので不要
+        // std::this_thread::sleep_for(sleepTime);
         s_overSleep = std::chrono::duration_cast<std::chrono::milliseconds>((std::chrono::system_clock::now() - s_end) - sleepTime);
     } else {
         s_overSleep = std::chrono::milliseconds(0);

--- a/src/App/mod/Utils/lib/Utils/Time.cpp
+++ b/src/App/mod/Utils/lib/Utils/Time.cpp
@@ -27,7 +27,8 @@ void Time::sync()
     float elapsedTime = s_end - s_start;
     float sleepTime = frameDuration - elapsedTime - s_overSleep;
     if (sleepTime > 0) {
-        ::Sleep((DWORD)(sleepTime * 1000.0f));
+        // NOTE: スワップチェインがリフレッシュレートに合わせて同期するのでそちらに任せる
+        // ::Sleep((DWORD)(sleepTime * 1000.0f));
         s_overSleep = (Clock::counter() - s_end) - sleepTime;
     } else {
         s_overSleep = 0;

--- a/src/App/mod/Utils/test/CMakeLists.txt
+++ b/src/App/mod/Utils/test/CMakeLists.txt
@@ -3,7 +3,7 @@ project(Lib-Utils-Test CXX)
 
 add_executable(Lib-Utils-Test main.cpp)
 target_compile_options(Lib-Utils-Test PRIVATE $<$<BOOL:${MSVC}>: /utf-8>)
-target_compile_features(Lib-Utils-Test PRIVATE cxx_std_17)
+target_compile_features(Lib-Utils-Test PRIVATE cxx_std_20)
 target_include_directories(
     Lib-Utils-Test
     PRIVATE

--- a/src/App/mod/Uuid/CMakeLists.txt
+++ b/src/App/mod/Uuid/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.25)
+project(
+    Lib-Uuid
+    VERSION 0.0.1
+    LANGUAGES CXX
+)
+#
+# Build Options
+#
+add_library(
+    Lib-Uuid
+    INTERFACE
+)
+find_path(
+    UUID_INCLUDE_DIRS
+    NAMES "stduuid/uuid.h"
+    PATHS "${VCPKG_PACKAGES_DIR}/stduuid_x64-windows"
+    SUFFIX include)
+target_include_directories(Lib-Uuid INTERFACE ${UUID_INCLUDE_DIRS})

--- a/src/App/test/CMakeLists.txt
+++ b/src/App/test/CMakeLists.txt
@@ -16,7 +16,7 @@ set_property(
 )
 target_compile_definitions(App-Test PRIVATE _TEST NOMINMAX)
 target_compile_options(App-Test PRIVATE $<$<BOOL:${MSVC}>: /utf-8>)
-target_compile_features(App-Test PRIVATE cxx_std_17)
+target_compile_features(App-Test PRIVATE cxx_std_20)
 target_include_directories(
     App-Test
     PRIVATE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,7 @@ set(SOLID_DEBUG_DEFINE
 )
 set(SOLID_RELEASE_DEFINE NOMINMAX SOLID_NDEBUG)
 set(SOLID_DEBUG_COMPILE
-    $<$<BOOL:${MSVC}>: /utf-8>
+    $<$<BOOL:${MSVC}>: /Ob1 /utf-8>
     $<$<NOT:$<BOOL:${MSVC}>>: -Og -g -Wall -Werror>
     $<$<NOT:${WIN32}>:-fsanitize=address>
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,7 +50,7 @@ function(app_target_compile_params target)
         $<$<CONFIG:Debug>:${SOLID_DEBUG_COMPILE}>
         $<$<CONFIG:Release>:${SOLID_RELEASE_COMPILE}>
     )
-    target_compile_features(${target} PRIVATE cxx_std_17)
+    target_compile_features(${target} PRIVATE cxx_std_20)
 endfunction()
 
 function(app_target_link_params target)
@@ -75,7 +75,7 @@ function(lib_target_compile_params target)
         $<$<CONFIG:Debug>:${SOLID_DEBUG_COMPILE}>
         $<$<CONFIG:Release>:${SOLID_RELEASE_COMPILE}>
     )
-    target_compile_features(${target} PRIVATE cxx_std_17)
+    target_compile_features(${target} PRIVATE cxx_std_20)
 endfunction()
 
 function(lib_target_link_params target)


### PR DESCRIPTION
* パフォーマンスプロファイラを確認、頻繁に呼ばれる関数はインライン化
* デバッグビルドであってもinline修飾された関数は必ずインライン化するようオプション設定
* 行列をijkからikjループに置き換え、加えてFMA命令を使うように最適化
* ベクトル、行列ともにループアンローリングを行うように
* ブルームの解像度が高すぎたので1/4にダウン
* std::arrayはランタイムの境界チェックのコストが高くつくので生配列に置き換え
* 全要素探索が遅いのでエンティティはそれぞれがuuidを持つように
* マルチスレッドレンダリングを導入、CPUとGPUが同時に仕事をするように